### PR TITLE
chore: Add a specialized `statefulMap` internal implement.

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -14,7 +14,6 @@
 package org.apache.pekko.http.impl.util
 
 import org.apache.pekko
-import org.apache.pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.NotUsed
 import pekko.actor.Cancellable
 import pekko.annotation.InternalApi
@@ -22,6 +21,7 @@ import pekko.dispatch.ExecutionContexts
 import pekko.http.scaladsl.model.HttpEntity
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream._
+import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream.impl.fusing.GraphInterpreter
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.scaladsl._

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -436,7 +436,7 @@ private[http] class EnhancedByteStringSource[Mat](val byteStringStream: Source[B
               case Supervision.Restart =>
                 statefulFunction = statefulFunctionConstructor()
                 tryPull(in)
-              case _ => tryPull(in)
+              case Supervision.Resume => tryPull(in)
             }
         }
       }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -433,7 +433,10 @@ private[http] class EnhancedByteStringSource[Mat](val byteStringStream: Source[B
           case NonFatal(ex) =>
             decider(ex) match {
               case Supervision.Stop => failStage(ex)
-              case _                => pull(in)
+              case Supervision.Restart =>
+                statefulFunction = statefulFunctionConstructor()
+                tryPull(in)
+              case _ => tryPull(in)
             }
         }
       }


### PR DESCRIPTION
Motivation:
In https://github.com/apache/incubator-pekko-http/issues/395 , @jrudolph said the current change may hurt performance, additional allocation for `(State, A)`, So I submit this, a simpler but still with the drawback for internal usage.

Result:
Performance keeped.