### PR TITLE
Improve too large chunk size test

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
@@ -544,11 +544,11 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
       "too-large chunk size" in new Test {
         Seq(
           start,
-          """400000
+          """1400000
             |""") should generalMultiParseTo(
           Right(baseRequest),
           Left(
-            EntityStreamError(ErrorInfo("HTTP chunk of 4194304 bytes exceeds the configured limit of 1048576 bytes"))))
+            EntityStreamError(ErrorInfo("HTTP chunk of 20971520 bytes exceeds the configured limit of 1048576 bytes"))))
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 


### PR DESCRIPTION
This is a followup of #528

The current test goes over the configured max chunk size when parsing the last hex char. The spirit of the code is to continue parsing the size even if we've already gone over the max chunk size. To actually test this we need to make sure another char follows after we've gone over the max chunk size.