### PR TITLE
Pin Scala 3.3 LTS in scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,6 +23,8 @@ updates.pin = [
   # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
+  # Scala 3.3 is a LTS
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]
 
 updatePullRequests = "always"


### PR DESCRIPTION
I noticed in Scala OS projects that Scala Steward has been bumping 3.3.x to 3.4.x