### PR TITLE
protobuf-java upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 target
 
 *.orig
+*.log
 
 *#
 *~

--- a/build.sbt
+++ b/build.sbt
@@ -350,7 +350,11 @@ lazy val httpScalafixRules =
   Project(id = "http-scalafix-rules", base = file("http-scalafix/scalafix-rules"))
     .settings(
       name := "pekko-http-scalafix-rules",
-      libraryDependencies += Dependencies.Compile.scalafix)
+      libraryDependencies ++= Seq(
+          Dependencies.Compile.scalafix,
+          Dependencies.Compile.protobufJava
+        )
+      )
     .enablePlugins(NoScala3)
     .disablePlugins(MimaPlugin) // tooling, no bin compat guaranteed
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val h2specArtifactExtension = if (h2specExe.endsWith("exe")) "zip" else "tar.gz"
   val h2specUrl =
     s"https://github.com/summerwind/h2spec/releases/download/v$h2specVersion/$h2specName.$h2specArtifactExtension"
+  val protobufJavaVersion = "3.21.12"
 
   val scalaTestVersion = "3.2.18"
   val scalaCheckVersion = "1.17.0"
@@ -67,6 +68,8 @@ object Dependencies {
     val scalafix = "ch.epfl.scala" %% "scalafix-core" % Dependencies.scalafixVersion
 
     val parboiled = "org.parboiled" %% "parboiled" % "2.5.1"
+
+    val protobufJava = "com.google.protobuf" % "protobuf-java" % protobufJavaVersion
 
     object Docs {
       val sprayJson = Compile.sprayJson % "test"


### PR DESCRIPTION
Address the following known issues with protobuf-java:
https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772
https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774

Before/after the fix, run:
```
sbt dependencyTree > output.log && grep -A1 -B1 "protobuf-java" output.log
```

*Output before*
```
...
[info]               +-com.google.protobuf:protobuf-java:3.19.6
...
```

*Output after*
```
...
[info]   |           +-com.google.protobuf:protobuf-java:3.19.6 (evicted by: 3.21.12)
[info]   |           +-com.google.protobuf:protobuf-java:3.21.12
...
```