### PR TITLE
fix deprecation warning in Untar.scala

### DIFF
--- a/project/Untar.scala
+++ b/project/Untar.scala
@@ -31,14 +31,14 @@ object Untar {
       val gzIn = new GzipCompressorInputStream(buffIn)
       Using(new TarArchiveInputStream(gzIn)) { tis =>
         toDirectory.mkdirs()
-        var entry = tis.getNextTarEntry
+        var entry = tis.getNextEntry
         while (entry ne null) {
           val name = entry.getName
           val outFile = new File(toDirectory, name)
           Using(new FileOutputStream(outFile)) { fos =>
             IOUtils.copy(tis, fos)
           }
-          entry = tis.getNextTarEntry
+          entry = tis.getNextEntry
         }
       }
     }


### PR DESCRIPTION
```
project/Untar.scala:34:25: method getNextTarEntry in class TarArchiveInputStream is deprecated
[warn]         var entry = tis.getNextTarEntry
```