### PR TITLE
Fix reference to an akka-http GitHub issue

### DIFF
--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -98,7 +98,7 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
     }
 
     "running on pekko dispatcher threads" in Await.result(Future {
-        // https://github.com/apache/pekko-http/pull/2526
+        // https://github.com/akka/akka-http/pull/2526
         // Check will block while waiting on the response, this might lead to starvation
         // on the BatchingExecutor of pekko's dispatcher if the blocking is not managed properly.
         Get() ~> complete(Future(HttpResponse())) ~> check {


### PR DESCRIPTION
I think this reference was changed in a mass search and replace, but it now links to the GitHub 404 page.