### PR TITLE
recovery testing for ContentLength

### DIFF
--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
@@ -325,12 +325,8 @@ class Http2ClientSpec extends PekkoSpecWithMaterializer("""
 
         val response = user.expectResponse()
         response.entity.contentType should ===(ContentTypes.`application/json`)
-
-        // FIXME: contentLength is not reported in all cases with HTTP/2
-        // see https://github.com/akka/akka-http/issues/3843
-        // response.entity.isIndefiniteLength should ===(false)
-        // response.entity.contentLengthOption should ===(Some(2000L))
-
+        response.entity.isIndefiniteLength should ===(false)
+        response.entity.contentLengthOption should ===(Some(2000L))
         network.sendDATA(TheStreamId, endStream = false, ByteString("x" * 1000))
         network.sendDATA(TheStreamId, endStream = true, ByteString("x" * 1000))
 

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
@@ -379,10 +379,8 @@ class Http2ServerSpec extends Http2SpecWithMaterializer("""
             protocol = HttpProtocols.`HTTP/2.0`)) {
 
           receivedRequest.entity.contentType should ===(ContentTypes.`application/json`)
-          // FIXME: contentLength is not reported in all cases with HTTP/2
-          // see https://github.com/akka/akka-http/issues/3843
-          // receivedRequest.entity.isIndefiniteLength should ===(false)
-          // receivedRequest.entity.contentLengthOption should ===(Some(1337L))
+          receivedRequest.entity.isIndefiniteLength should ===(false)
+          receivedRequest.entity.contentLengthOption should ===(Some(1337L))
           entityDataIn.expectBytes(ByteString("x" * 1337))
           entityDataIn.expectComplete()
         })

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/RequestParsingSpec.scala
@@ -535,9 +535,7 @@ class RequestParsingSpec extends PekkoSpecWithMaterializer with Inside with Insp
           Host(Uri.Host("example.org")))
         inside(request.entity) {
           case entity: HttpEntity =>
-            // FIXME: contentLength is not reported in all cases with HTTP/2
-            // see https://github.com/akka/akka-http/issues/3843
-            // entity.contentLength should ===(123.toLong)
+            entity.contentLengthOption shouldBe Some(123.toLong)
             entity.contentType should ===(ContentType(MediaTypes.`image/jpeg`))
         }
         request.protocol should ===(HttpProtocols.`HTTP/2.0`)


### PR DESCRIPTION
##motivation
try to resolve a FIXME

```shell
        // FIXME: contentLength is not reported in all cases with HTTP/2
        // see https://github.com/akka/akka-http/issues/3843
```
##result 
recovery testing for ContentLength
