### PR TITLE
use optimised ByteString.asInputStream

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -27,7 +27,7 @@ import pekko.util.ByteString.ByteString1C
 @InternalApi
 private[http2] object ByteStringInputStream {
 
-  private lazy val byteStringInputStreamMethodTypeOpt = Try {
+  private val byteStringInputStreamMethodTypeOpt = Try {
     val lookup = MethodHandles.publicLookup()
     val inputStreamMethodType = MethodType.methodType(classOf[InputStream])
     lookup.findVirtual(classOf[ByteString], "asInputStream", inputStreamMethodType)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -14,6 +14,9 @@
 package org.apache.pekko.http.impl.engine.http2.hpack
 
 import java.io.{ ByteArrayInputStream, InputStream }
+import java.lang.invoke.{ MethodHandles, MethodType }
+
+import scala.util.Try
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
@@ -24,10 +27,22 @@ import pekko.util.ByteString.ByteString1C
 @InternalApi
 private[http2] object ByteStringInputStream {
 
+  private lazy val byteStringInputStreamMethodTypeOpt = Try {
+    val lookup = MethodHandles.publicLookup()
+    val inputStreamMethodType = MethodType.methodType(classOf[InputStream])
+    lookup.findVirtual(classOf[ByteString], "asInputStream", inputStreamMethodType)
+  }.toOption
+
   def apply(bs: ByteString): InputStream =
+    byteStringInputStreamMethodTypeOpt.map { mh =>
+      mh.invoke(bs).asInstanceOf[InputStream]
+    }.getOrElse {
+      legacyConvert(bs)
+    }
+
+  private def legacyConvert(bs: ByteString): InputStream =
     bs match {
       case cs: ByteString1C =>
-        // TODO optimise, ByteString needs to expose InputStream (esp if array backed, nice!)
         new ByteArrayInputStream(cs.toArrayUnsafe())
       case _ =>
         // NOTE: We actually measured recently, and compact + use array was pretty good usually

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -35,21 +35,25 @@ private[http2] object ByteStringInputStream {
 
   def apply(bs: ByteString): InputStream = bs match {
     case cs: ByteString1C =>
-      new ByteArrayInputStream(cs.toArrayUnsafe())
+      getInputStreamUnsafe(cs)
     case _ => {
       byteStringInputStreamMethodTypeOpt.map { mh =>
         mh.invoke(bs).asInstanceOf[InputStream]
       }.getOrElse {
-        legacyConvert(bs)
+        legacyConvert(bs.compact)
       }
     }
   }
 
   private def legacyConvert(bs: ByteString): InputStream = bs match {
     case cs: ByteString1C =>
-      new ByteArrayInputStream(cs.toArrayUnsafe())
+      getInputStreamUnsafe(cs)
     case _ =>
       // NOTE: We actually measured recently, and compact + use array was pretty good usually
       legacyConvert(bs.compact)
   }
+
+  private def getInputStreamUnsafe(bs: ByteString): InputStream =
+    new ByteArrayInputStream(bs.toArrayUnsafe())
+
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -36,13 +36,12 @@ private[http2] object ByteStringInputStream {
   def apply(bs: ByteString): InputStream = bs match {
     case cs: ByteString1C =>
       getInputStreamUnsafe(cs)
-    case _ => {
-      byteStringInputStreamMethodTypeOpt.map { mh =>
-        mh.invoke(bs).asInstanceOf[InputStream]
-      }.getOrElse {
+    case _ =>
+      if (byteStringInputStreamMethodTypeOpt.isDefined) {
+        byteStringInputStreamMethodTypeOpt.get.invoke(bs).asInstanceOf[InputStream]
+      } else {
         legacyConvert(bs.compact)
       }
-    }
   }
 
   private def legacyConvert(bs: ByteString): InputStream = bs match {


### PR DESCRIPTION
* ByteString.asInputStream is only in Pekko 1.1 - so if you use this code with Pekko 1.0, the MethodHandle will not work and the code falls back to existing ByteArrayInputStream