### PR TITLE
Revert "use optimised ByteString.asInputStream (#539)"

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -14,9 +14,6 @@
 package org.apache.pekko.http.impl.engine.http2.hpack
 
 import java.io.{ ByteArrayInputStream, InputStream }
-import java.lang.invoke.{ MethodHandles, MethodType }
-
-import scala.util.Try
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
@@ -27,32 +24,13 @@ import pekko.util.ByteString.ByteString1C
 @InternalApi
 private[http2] object ByteStringInputStream {
 
-  private val byteStringInputStreamMethodTypeOpt = Try {
-    val lookup = MethodHandles.publicLookup()
-    val inputStreamMethodType = MethodType.methodType(classOf[InputStream])
-    lookup.findVirtual(classOf[ByteString], "asInputStream", inputStreamMethodType)
-  }.toOption
-
-  def apply(bs: ByteString): InputStream = bs match {
-    case cs: ByteString1C =>
-      getInputStreamUnsafe(cs)
-    case _ =>
-      if (byteStringInputStreamMethodTypeOpt.isDefined) {
-        byteStringInputStreamMethodTypeOpt.get.invoke(bs).asInstanceOf[InputStream]
-      } else {
-        legacyConvert(bs.compact)
-      }
-  }
-
-  private def legacyConvert(bs: ByteString): InputStream = bs match {
-    case cs: ByteString1C =>
-      getInputStreamUnsafe(cs)
-    case _ =>
-      // NOTE: We actually measured recently, and compact + use array was pretty good usually
-      legacyConvert(bs.compact)
-  }
-
-  private def getInputStreamUnsafe(bs: ByteString): InputStream =
-    new ByteArrayInputStream(bs.toArrayUnsafe())
-
+  def apply(bs: ByteString): InputStream =
+    bs match {
+      case cs: ByteString1C =>
+        // TODO optimise, ByteString needs to expose InputStream (esp if array backed, nice!)
+        new ByteArrayInputStream(cs.toArrayUnsafe())
+      case _ =>
+        // NOTE: We actually measured recently, and compact + use array was pretty good usually
+        apply(bs.compact)
+    }
 }


### PR DESCRIPTION
This reverts commit 03f128907cf55ff2e1777ee0b6fc75d58c7188b9.

see #549 