### PR TITLE
Update format.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,6 +19,6 @@ jobs:
           persist-credentials: false
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v3
+        uses: jrouly/scalafmt-native-action@v4
         with:
           arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
use scalafmt-native-action@v4 because it supports Node 20 (and Node 16 support is being withdrawn by GitHub CI)