### PR TITLE
fix issue in listDirectoryContents test

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -325,7 +325,7 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
   }
 
   "listDirectoryContents" should {
-    val base = new File(getClass.getClassLoader.getResource("").toURI).getPath
+    val base = testRoot.getPath
     new File(base, "subDirectory/emptySub").mkdir()
     def eraseDateTime(s: String) = s.replaceAll("""\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d""", "xxxx-xx-xx xx:xx:xx")
     val settings = RoutingSettings.default.withRenderVanityFooter(false)


### PR DESCRIPTION
see #558 

the issue may be down to classloading changes in sbt 1.10.0 - only recent change in this repo

still, the testRoot val seems tidier and works fine when tested on my laptop