### PR TITLE
fix parse broken when header value is null (#575)

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/HeaderParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/HeaderParser.scala
@@ -86,8 +86,9 @@ private[http] class HeaderParser(
   def failure(error: Throwable): HeaderParser.Failure =
     HeaderParser.Failure {
       error match {
-        case IllegalUriException(info) => info
-        case NonFatal(e)               => ErrorInfo.fromCompoundString(e.getMessage)
+        case IllegalUriException(info)           => info
+        case NonFatal(e) if e.getMessage == null => ErrorInfo.fromCompoundString(e.toString)
+        case NonFatal(e)                         => ErrorInfo.fromCompoundString(e.getMessage)
       }
     }
   def ruleNotFound(ruleName: String): Result = HeaderParser.RuleNotFound

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
@@ -876,6 +876,13 @@ class HttpHeaderSpec extends AnyFreeSpec with Matchers {
       parse("User-Agent", "(" * 10000).errors.head shouldEqual
       ErrorInfo("Illegal HTTP header 'User-Agent': Illegal header value", "Header comment nested too deeply")
     }
+
+    "should not broken when header-value is null" in {
+      val errors = parse("Content-Disposition", null).errors
+      errors should have size 1
+      errors.head shouldBe an[ErrorInfo]
+    }
+
   }
 
   implicit class TestLine(line: String) {


### PR DESCRIPTION
cherry pick 41e4f46e35f4ef90a30b5d6a924413a83c3fa110 #575

issue https://github.com/apache/pekko-http/issues/574