### PR TITLE
Increase stream-cancellation-delay default to 1000 millis

### DIFF
--- a/docs/src/main/paradox/release-notes/releases-1.1.md
+++ b/docs/src/main/paradox/release-notes/releases-1.1.md
@@ -12,6 +12,7 @@ All the changes in the @ref:[1.0.x releases](releases-1.0.md) up to and includin
 ### Changes
 * Changed names of HTTP status codes 413 and 422 ([PR87](https://github.com/apache/pekko-http/pull/87))
 * Parse entire HTTP chunk size ([PR528](https://github.com/apache/pekko-http/pull/528))
+* Increased default value of `pekko.http.server.stream-cancellation-delay` and `pekko.http.client.stream-cancellation-delay` from 100 to 1000 millis ([PR590](https://github.com/apache/pekko-http/pull/590))
 
 ### Additions
 * Add UnsupportedContentTypeException Java DSL ([PR376](https://github.com/apache/pekko-http/pull/376))

--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -222,7 +222,7 @@ pekko.http {
     # In most cases, there should be no reason to change this setting.
     #
     # Set to 0 to disable the delay.
-    stream-cancellation-delay = 100 millis
+    stream-cancellation-delay = 1000 millis
 
     http2 {
       # The maximum number of request per connection concurrently dispatched to the request handler.
@@ -532,7 +532,7 @@ pekko.http {
     # In most cases, there should be no reason to change this setting.
     #
     # Set to 0 to disable the delay.
-    stream-cancellation-delay = 100 millis
+    stream-cancellation-delay = 1000 millis
   }
   #client-settings
 

--- a/http-core/src/test/resources/reference.conf
+++ b/http-core/src/test/resources/reference.conf
@@ -6,4 +6,5 @@ pekko {
     default-dispatcher.throughput = 1
   }
   stream.materializer.debug.fuzzing-mode = off
+  stream.testkit.all-stages-stopped-timeout = 20 s
 }

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -306,6 +306,7 @@ class H2SpecIntegrationSpec extends PekkoFreeSpec(
         executable,
         "-k", "-t",
         "-p", port.toString,
+        "-o", "9",
         "-j", junitOutput.getPath) ++
         specSectionNumber.toList.map(number => s"http2/$number")
 


### PR DESCRIPTION
References: https://github.com/apache/pekko-http/issues/422

Still need to update tests as per @jrudolph original comment, i.e.

> That broke lots of tests that probably didn't automatically propagate closing so they now fail while waiting for the now ten times longer cancellation times... (Might still might sense to "just" fix those tests)