### PR TITLE
Revert "Increase stream-cancellation-delay default to 1000 millis"

### DIFF
--- a/docs/src/main/paradox/release-notes/releases-1.1.md
+++ b/docs/src/main/paradox/release-notes/releases-1.1.md
@@ -12,7 +12,6 @@ All the changes in the @ref:[1.0.x releases](releases-1.0.md) up to and includin
 ### Changes
 * Changed names of HTTP status codes 413 and 422 ([PR87](https://github.com/apache/pekko-http/pull/87))
 * Parse entire HTTP chunk size ([PR528](https://github.com/apache/pekko-http/pull/528))
-* Increased default value of `pekko.http.server.stream-cancellation-delay` and `pekko.http.client.stream-cancellation-delay` from 100 to 1000 millis ([PR590](https://github.com/apache/pekko-http/pull/590))
 
 ### Additions
 * Add UnsupportedContentTypeException Java DSL ([PR376](https://github.com/apache/pekko-http/pull/376))

--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -222,7 +222,7 @@ pekko.http {
     # In most cases, there should be no reason to change this setting.
     #
     # Set to 0 to disable the delay.
-    stream-cancellation-delay = 1000 millis
+    stream-cancellation-delay = 100 millis
 
     http2 {
       # The maximum number of request per connection concurrently dispatched to the request handler.
@@ -532,7 +532,7 @@ pekko.http {
     # In most cases, there should be no reason to change this setting.
     #
     # Set to 0 to disable the delay.
-    stream-cancellation-delay = 1000 millis
+    stream-cancellation-delay = 100 millis
   }
   #client-settings
 

--- a/http-core/src/test/resources/reference.conf
+++ b/http-core/src/test/resources/reference.conf
@@ -6,5 +6,4 @@ pekko {
     default-dispatcher.throughput = 1
   }
   stream.materializer.debug.fuzzing-mode = off
-  stream.testkit.all-stages-stopped-timeout = 20 s
 }

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -306,7 +306,6 @@ class H2SpecIntegrationSpec extends PekkoFreeSpec(
         executable,
         "-k", "-t",
         "-p", port.toString,
-        "-o", "9",
         "-j", junitOutput.getPath) ++
         specSectionNumber.toList.map(number => s"http2/$number")
 


### PR DESCRIPTION
Reverts apache/pekko-http#590

Still open for discussion. See https://lists.apache.org/thread/h59dphf5j20tzjwrm1z1c8olptnqrrhy