### PR TITLE
don't link to 'current' pekko docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -444,7 +444,7 @@ lazy val docs = project("docs")
       "pekko.version" -> PekkoCoreDependency.version,
       "jackson.xml.version" -> Dependencies.jacksonXmlVersion,
       "scalafix.version" -> _root_.scalafix.sbt.BuildInfo.scalafixVersion, // grab from scalafix plugin directly
-      "extref.pekko-docs.base_url" -> s"https://pekko.apache.org/docs/pekko/current/%s",
+      "extref.pekko-docs.base_url" -> s"https://pekko.apache.org/docs/pekko/${PekkoCoreDependency.default.link}/%s",
       "javadoc.java.base_url" -> "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/",
       "javadoc.java.link_style" -> "direct",
       "javadoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/japi/pekko/${PekkoCoreDependency.default.link}",


### PR DESCRIPTION
link to the version specific docs