### PR TITLE
don't link to 'current' pekko docs (#603)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -440,7 +440,7 @@ lazy val docs = project("docs")
       "pekko.version" -> PekkoCoreDependency.version,
       "jackson.xml.version" -> Dependencies.jacksonXmlVersion,
       "scalafix.version" -> _root_.scalafix.sbt.BuildInfo.scalafixVersion, // grab from scalafix plugin directly
-      "extref.pekko-docs.base_url" -> s"https://pekko.apache.org/docs/pekko/current/%s",
+      "extref.pekko-docs.base_url" -> s"https://pekko.apache.org/docs/pekko/${PekkoCoreDependency.default.link}/%s",
       "javadoc.java.base_url" -> "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/",
       "javadoc.java.link_style" -> "direct",
       "javadoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/japi/pekko/${PekkoCoreDependency.default.link}",


### PR DESCRIPTION
cherry pick c8ea51c49b2c39d3369ba6f1e8343c46214f19f0 #603 

this fixes a link issue in our migration docs that point to a 'current' doc link that no longer works