### PR TITLE
increase xmx for sbt due to mem issues in build

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,4 @@
+-Xmx4g
 -Duser.language=en_US.UTF-8
 -Dfile.encoding=en_US.UTF-8
 -Dsun.jnu.encoding=UTF-8


### PR DESCRIPTION
Had mem issues while publishing v1.1.0-RC1. This has been an ongoing issue with previous releases too.