### PR TITLE
uptake sbt-apache-sonatype release via sbt-pekko-build

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,6 @@
  */
 
 resolvers += Classpaths.sbtPluginReleases
-resolvers += Classpaths.typesafeReleases
 
 addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "0.6.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
@@ -29,7 +28,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.4")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.0")
 addSbtPlugin("net.virtual-void" % "sbt-hackers-digest" % "0.1.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 


### PR DESCRIPTION
uptakes https://github.com/mdedetrich/sbt-apache-sonatype/pull/40
via https://github.com/pjfanning/sbt-pekko-build/pull/15

we don't really need the typesafe resolver any more either