### PR TITLE
use convertIterable to wrap java Iterables

### DIFF
--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Rejections.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Rejections.scala
@@ -25,7 +25,7 @@ import java.lang.{ Iterable => JIterable }
 
 import pekko.annotation.DoNotInherit
 import pekko.http.scaladsl
-import pekko.japi.Util
+import pekko.http.impl.util.Util
 import pekko.pattern.CircuitBreakerOpenException
 import pekko.util.OptionConverters._
 
@@ -416,7 +416,8 @@ object Rejections {
     s.UnsupportedRequestEncodingRejection(supported.asScala)
 
   def unsatisfiableRange(unsatisfiableRanges: java.lang.Iterable[ByteRange], actualEntityLength: Long) =
-    UnsatisfiableRangeRejection(Util.immutableSeq(unsatisfiableRanges).map(_.asScala), actualEntityLength)
+    UnsatisfiableRangeRejection(Util.convertIterable[ByteRange, ByteRange](unsatisfiableRanges).map(_.asScala),
+      actualEntityLength)
 
   def tooManyRanges(maxRanges: Int) = TooManyRangesRejection(maxRanges)
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RouteResult.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RouteResult.scala
@@ -28,8 +28,7 @@ trait Rejected extends RouteResult {
 
 object RouteResults {
   import pekko.http.scaladsl.{ server => s }
-  import pekko.japi.Util
-  import pekko.http.impl.util.JavaMapping
+  import pekko.http.impl.util.{ JavaMapping, Util }
   import JavaMapping.Implicits._
   import RoutingJavaMapping._
 
@@ -38,7 +37,7 @@ object RouteResults {
   }
 
   def rejected(rejections: java.lang.Iterable[Rejection]): Rejected = {
-    s.RouteResult.Rejected(Util.immutableSeq(rejections).map(_.asScala))
+    s.RouteResult.Rejected(Util.convertIterable[Rejection, Rejection](rejections).map(_.asScala))
   }
 
 }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
@@ -18,7 +18,7 @@ import java.util.Optional
 import java.util.function.Function
 
 import org.apache.pekko
-import pekko.japi.Util
+import pekko.http.impl.util.Util
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.{ ByteRange, HttpChallenge, HttpEncoding }
 import pekko.http.javadsl.{ model, server => jserver }
@@ -335,7 +335,9 @@ final case class TransformationRejection(transform: immutable.Seq[Rejection] => 
     override def apply(t: Iterable[jserver.Rejection]): Iterable[jserver.Rejection] = {
       // explicit collects assignment is because of unidoc failing compilation on .asScala and .asJava here
       val transformed: Seq[jserver.Rejection] =
-        transform(Util.immutableSeq(t).collect { case r: Rejection => r }).collect { case j: jserver.Rejection => j }
+        transform(Util.convertIterable[jserver.Rejection, jserver.Rejection](t).collect { case r: Rejection =>
+          r
+        }).collect { case j: jserver.Rejection => j }
       transformed.asJava // TODO "asJavaDeep" and optimise?
     }
   }


### PR DESCRIPTION
Util.immutableSeq creates a new Seq by copying the items from the original iterable but convertIterable wraps the original iterable (using Scala Collection Converters).