### PR TITLE
annotate some instrumented methods with @noinline

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
@@ -75,6 +75,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
   val telemetry = TelemetrySpi.create(system)
 
   // TODO: split up similarly to what `Http` does into `serverLayer`, `bindAndHandle`, etc.
+  @noinline // Not inlined to permit instrumentation to pass params (interface, port) as context to constructed implementation flows
   def bindAndHandleAsync(
       handler: HttpRequest => Future[HttpResponse],
       interface: String, port: Int = DefaultPortForProtocol,

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Blueprint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2Blueprint.scala
@@ -296,6 +296,7 @@ private[http] object Http2Blueprint {
    * Returns a flow that handles `parallelism` requests in parallel, automatically keeping track of the
    * Http2StreamIdHeader between request and responses.
    */
+  @noinline // Not inlined so that we can instrument the produced flow with e.g. tracing downstream
   def handleWithStreamIdHeader(parallelism: Int)(handler: HttpRequest => Future[HttpResponse])(
       implicit ec: ExecutionContext): Flow[HttpRequest, HttpResponse, NotUsed] =
     Flow[HttpRequest]


### PR DESCRIPTION
In a similar vein to https://github.com/apache/pekko/pull/1489, this fixes Kamon instrumentation of http2 flows in pekko-http 1.1.+. (cf https://github.com/kamon-io/Kamon/pull/1362 , which fails on https instrumentation tests)