### PR TITLE
CI: install sbt

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,8 +7,11 @@ jobs:
   dependency-graph:
     name: Update Dependency Graph
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/pekko-http'    
     steps:
       - uses: actions/checkout@v4
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1      
       - uses: scalacenter/sbt-dependency-submission@v2
         with:
           modules-ignore: pekko-http-tests_3 pekko-http-docs_3

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   check-headers:
     name: Check headers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,6 +18,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate-links:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'apache/pekko-http'
     steps:
       - name: Checkout
@@ -28,6 +28,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1          
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,9 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.JDK }}
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1          
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -39,6 +39,9 @@ jobs:
           distribution: temurin
           java-version: 8
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 

--- a/.github/workflows/publish-1.0-snapshots.yml
+++ b/.github/workflows/publish-1.0-snapshots.yml
@@ -24,6 +24,9 @@ jobs:
           distribution: temurin
           java-version: 8
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -38,6 +38,9 @@ jobs:
           distribution: temurin
           java-version: 8
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
           distribution: temurin
           java-version: 8
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
@@ -52,6 +55,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -29,6 +29,9 @@ jobs:
           distribution: temurin
           java-version: 8
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
@@ -74,6 +77,9 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.JDK }}
 
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+  
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 


### PR DESCRIPTION
We can no longer rely on sbt being pre-installed in CI envs.

https://eed3si9n.com/setup-sbt/

see broken jobs in https://github.com/apache/pekko-http/pull/618/checks

`ubuntu-latest` is now ubuntu-24 and as documented in the eed3si9n.com article, that does not have sbt pre-installed

we use a lot of different versions of ubuntu in our builds - change to use ubuntu 22 as a min