### PR TITLE
Fix partial match

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRendering.scala
@@ -99,7 +99,7 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
       r.attribute(AttributeKeys.trailer) match {
         case Some(trailer) if trailer.headers.nonEmpty =>
           OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None))
-        case None => OptionVal.None
+        case _ => OptionVal.None
       }
 
     Http2SubStream(r.entity, headersFrame, trailingHeadersFrame,

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -25,7 +25,7 @@ import scala.collection.immutable.VectorBuilder
 import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
+import scala.collection.immutable.Seq
 import scala.collection.immutable
 
 object MyCustomHeader extends ModeledCustomHeaderCompanion[MyCustomHeader] {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -26,6 +26,8 @@ import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.collection.immutable
+
 object MyCustomHeader extends ModeledCustomHeaderCompanion[MyCustomHeader] {
   override def name: String = "custom-header"
   override def parse(value: String): Try[MyCustomHeader] = ???
@@ -163,12 +165,12 @@ class HttpMessageRenderingSpec extends AnyWordSpec with Matchers {
 
   }
 
-  private def renderClientHeaders(headers: Seq[HttpHeader], builder: VectorBuilder[(String, String)],
+  private def renderClientHeaders(headers: immutable.Seq[HttpHeader], builder: VectorBuilder[(String, String)],
       peerIdHeader: Option[(String, String)] = None): Unit =
     HttpMessageRendering.renderHeaders(headers, builder, peerIdHeader, NoLogging, isServer = false,
       shouldRenderAutoHeaders = true, dateHeaderRendering = DateHeaderRendering.Unavailable)
 
-  private def renderServerHeaders(headers: Seq[HttpHeader], builder: VectorBuilder[(String, String)],
+  private def renderServerHeaders(headers: immutable.Seq[HttpHeader], builder: VectorBuilder[(String, String)],
       peerIdHeader: Option[(String, String)] = None): Unit =
     HttpMessageRendering.renderHeaders(headers, builder, peerIdHeader, NoLogging, isServer = true,
       shouldRenderAutoHeaders = true,

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -13,20 +13,22 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
-import com.typesafe.config.ConfigFactory
 import java.time.format.DateTimeFormatter
+
+import com.typesafe.config.ConfigFactory
 import org.apache.pekko
 import pekko.event.NoLogging
 import pekko.http.impl.engine.rendering.DateHeaderRendering
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
-import scala.collection.immutable.VectorBuilder
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.immutable.VectorBuilder
 import scala.collection.immutable.Seq
 import scala.collection.immutable
+import scala.util.Try
 
 object MyCustomHeader extends ModeledCustomHeaderCompanion[MyCustomHeader] {
   override def name: String = "custom-header"

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.http.impl.engine.http2
 import com.typesafe.config.ConfigFactory
 import java.time.format.DateTimeFormatter
 import org.apache.pekko
-import org.apache.pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
+import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import pekko.event.NoLogging
 import pekko.http.impl.engine.rendering.DateHeaderRendering
 import pekko.http.scaladsl.model.headers._
@@ -25,8 +25,6 @@ import scala.collection.immutable.VectorBuilder
 import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import scala.collection.immutable
 
 object MyCustomHeader extends ModeledCustomHeaderCompanion[MyCustomHeader] {
   override def name: String = "custom-header"
@@ -165,18 +163,18 @@ class HttpMessageRenderingSpec extends AnyWordSpec with Matchers {
 
   }
 
-  private def renderClientHeaders(headers: immutable.Seq[HttpHeader], builder: VectorBuilder[(String, String)],
+  private def renderClientHeaders(headers: Seq[HttpHeader], builder: VectorBuilder[(String, String)],
       peerIdHeader: Option[(String, String)] = None): Unit =
     HttpMessageRendering.renderHeaders(headers, builder, peerIdHeader, NoLogging, isServer = false,
       shouldRenderAutoHeaders = true, dateHeaderRendering = DateHeaderRendering.Unavailable)
 
-  private def renderServerHeaders(headers: immutable.Seq[HttpHeader], builder: VectorBuilder[(String, String)],
+  private def renderServerHeaders(headers: Seq[HttpHeader], builder: VectorBuilder[(String, String)],
       peerIdHeader: Option[(String, String)] = None): Unit =
     HttpMessageRendering.renderHeaders(headers, builder, peerIdHeader, NoLogging, isServer = true,
       shouldRenderAutoHeaders = true,
       dateHeaderRendering = dateHeaderRendering)
 
-  private lazy val dateHeaderRendering = new DateHeaderRendering {
+  private lazy val dateHeaderRendering: DateHeaderRendering = new DateHeaderRendering {
     // fake date rendering
     override def renderHeaderPair(): (String, String) = "date" -> DateTime.now.toRfc1123DateTimeString
     override def renderHeaderBytes(): Array[Byte] = ???

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -16,11 +16,11 @@ package org.apache.pekko.http.impl.engine.http2
 import com.typesafe.config.ConfigFactory
 import java.time.format.DateTimeFormatter
 import org.apache.pekko
-import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import pekko.event.NoLogging
 import pekko.http.impl.engine.rendering.DateHeaderRendering
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import scala.collection.immutable.VectorBuilder
 import scala.util.Try
 import org.scalatest.matchers.should.Matchers

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import com.typesafe.config.ConfigFactory
 import java.time.format.DateTimeFormatter
 import org.apache.pekko
+import org.apache.pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import pekko.event.NoLogging
 import pekko.http.impl.engine.rendering.DateHeaderRendering
 import pekko.http.scaladsl.model.headers._
-import pekko.http.scaladsl.model.{ ContentTypes, DateTime, HttpHeader, TransferEncodings }
-
-import scala.collection.immutable.Seq
+import pekko.http.scaladsl.model._
 import scala.collection.immutable.VectorBuilder
 import scala.util.Try
 import org.scalatest.matchers.should.Matchers
@@ -147,6 +147,22 @@ class HttpMessageRenderingSpec extends AnyWordSpec with Matchers {
       value1.exists(_._1 == "date") shouldBe false
     }
 
+    "handle empty trailer" in {
+      val config = ConfigFactory.load("reference.conf")
+      Try {
+        val rendering = new RequestRendering(ClientConnectionSettings(config), NoLogging)
+        rendering(HttpRequest().withAttributes(Map(AttributeKeys.trailer -> Trailer())))
+      }.isSuccess shouldBe true
+      Try {
+        val rendering = new ResponseRendering(ServerSettings(config), NoLogging, dateHeaderRendering)
+        rendering(
+          HttpResponse().withAttributes(
+            Map(
+              AttributeKeys.trailer -> Trailer(),
+              Http2.streamId -> 0)))
+      }.isSuccess shouldBe true
+    }
+
   }
 
   private def renderClientHeaders(headers: immutable.Seq[HttpHeader], builder: VectorBuilder[(String, String)],
@@ -158,10 +174,12 @@ class HttpMessageRenderingSpec extends AnyWordSpec with Matchers {
       peerIdHeader: Option[(String, String)] = None): Unit =
     HttpMessageRendering.renderHeaders(headers, builder, peerIdHeader, NoLogging, isServer = true,
       shouldRenderAutoHeaders = true,
-      dateHeaderRendering = new DateHeaderRendering {
-        // fake date rendering
-        override def renderHeaderPair(): (String, String) = "date" -> DateTime.now.toRfc1123DateTimeString
-        override def renderHeaderBytes(): Array[Byte] = ???
-        override def renderHeaderValue(): String = ???
-      })
+      dateHeaderRendering = dateHeaderRendering)
+
+  private lazy val dateHeaderRendering = new DateHeaderRendering {
+    // fake date rendering
+    override def renderHeaderPair(): (String, String) = "date" -> DateTime.now.toRfc1123DateTimeString
+    override def renderHeaderBytes(): Array[Byte] = ???
+    override def renderHeaderValue(): String = ???
+  }
 }


### PR DESCRIPTION
I hit this case in a test and it threw. I am not sure if when `trailer.headers` is empty, it should return None or a parsed frame with empty headers but I figured the guard was there for a reason