### PR TITLE
Get string representation of javadsl Content and Media Type

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
@@ -70,7 +70,7 @@ public class CustomMediaTypesExampleTest extends JUnitRouteTest {
         extractRequest(
             req ->
                 complete(
-                    req.entity().getContentType().toString()
+                    req.entity().getContentType().value()
                         + " = "
                         + req.entity().getContentType().getClass()));
 

--- a/http-core/src/main/mima-filters/1.2.x.backwards.excludes/content-media-type-value-string.backwards.excludes
+++ b/http-core/src/main/mima-filters/1.2.x.backwards.excludes/content-media-type-value-string.backwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.javadsl.model.ContentType.value")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.javadsl.model.MediaType.value")

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ContentType.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ContentType.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.javadsl.model
 
+import org.apache.pekko.annotation.DoNotInherit
+
 import java.util.Optional
 
 // Has to be defined in Scala even though it's JavaDSL because of:
@@ -45,6 +47,7 @@ object ContentType {
  *
  * See [[ContentTypes]] for convenience access to often used values.
  */
+@DoNotInherit
 trait ContentType {
 
   /**
@@ -61,4 +64,10 @@ trait ContentType {
    * Returns the charset if this ContentType is non-binary.
    */
   def getCharsetOption: Optional[HttpCharset]
+
+  /**
+   * Returns the string representation of this ContentType
+   * @since 1.2.0
+   */
+  def value: String
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/MediaType.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/MediaType.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.javadsl.model
 
+import org.apache.pekko.annotation.DoNotInherit
+
 /**
  * Represents an Http media-type. A media-type consists of a main-type and a sub-type.
  *
@@ -65,6 +67,7 @@ object MediaType {
   }
 }
 
+@DoNotInherit
 trait MediaType {
 
   /**
@@ -110,4 +113,10 @@ trait MediaType {
    * Creates a media-range from this media-type with a given qValue.
    */
   def toRange(qValue: Float): MediaRange
+
+  /**
+   * Returns the string representation of this MediaType
+   * @since 1.2.0
+   */
+  def value: String
 }


### PR DESCRIPTION
Currently in the javadsl its not possible to get the string representation of the `Content-Type`/`Media-Type` because its only the scaladsl that implements the `value` function (via the `ValueRenderable` trait). This PR adds the `value` method to the core Java interfaces (the `render` method is anyways implemented in the subclasses hence why this PR is compiling without any additional changes)

As a workaround I currently have to do this (its in kotlin but should be understandable)

```kotlin
internal fun contentTypeToString(contentType: ContentType): String {
    return when (contentType) {
        is org.apache.pekko.http.scaladsl.model.ContentType ->
            return contentType.value()
        else -> throw RuntimeException("Unsupported content type: ${contentType::class.qualifiedName}")
    }
}
```

This works because it just so happens that every javdsl `ContentType` is also a scaladsl `ContentType`