### PR TITLE
Optimized Uri.withQuery

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
@@ -129,7 +129,8 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
   /**
    * Returns a copy of this Uri with the given query.
    */
-  def withQuery(query: Query): Uri = copy(rawQueryString = if (query.isEmpty) None else Some(query.toString))
+  def withQuery(query: Query): Uri =
+    createUnsafe(scheme, authority, path, if (query.isEmpty) None else Some(query.toString), fragment)
 
   /**
    * Returns a copy of this Uri with the given query string.

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/UriSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/UriSpec.scala
@@ -818,6 +818,12 @@ class UriSpec extends AnyWordSpec with Matchers {
       uri.withRawQueryString("param1=val%22ue1") shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
       uri.withRawQueryString("param1=val\"ue1") shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
 
+      uri.withQuery(Query("param1=val\"ue1")) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
+      uri.withQuery(Query(("param1", "val\"ue1"))) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
+      uri.withQuery(Query(Some("param1=val\"ue1"))) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
+      val query = Query.newBuilder.addOne("param1" -> "val\"ue1").result()
+      uri.withQuery(query) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
+
       uri.withFragment("otherFragment") shouldEqual Uri("http://host/path?query#otherFragment")
     }
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/UriSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/UriSpec.scala
@@ -821,7 +821,7 @@ class UriSpec extends AnyWordSpec with Matchers {
       uri.withQuery(Query("param1=val\"ue1")) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
       uri.withQuery(Query(("param1", "val\"ue1"))) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
       uri.withQuery(Query(Some("param1=val\"ue1"))) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
-      val query = Query.newBuilder.addOne("param1" -> "val\"ue1").result()
+      val query = Query.newBuilder.+=("param1" -> "val\"ue1").result()
       uri.withQuery(query) shouldEqual Uri("http://host/path?param1=val%22ue1#fragment")
 
       uri.withFragment("otherFragment") shouldEqual Uri("http://host/path?query#otherFragment")


### PR DESCRIPTION
`Uri.withQuery` receives a `Query` object, converts it to a string, and then calls the `Uri.copy` method which creates a new `Uri` object with the given query (The `Uri` class holds the query as an un-parsed string).
The `copy` method ends up in `queryString.map(new UriParser(_).parseRawQueryString())` which percent-encodes the query string.
As in this flow, the query string is converted from a `Query` object, it is always percent-encoded, so the additional encoding operation is unnecessary. We can skip it by replacing the call to `copy` with `createUnsafe`.