### PR TITLE
jackson 2.18.2

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -12,8 +12,8 @@ updates.ignore = [
 
 updates.pin = [
   # pin to jackson version used in pekko-core 
-  { groupId = "com.fasterxml.jackson.core", version = "2.17." },
-  { groupId = "com.fasterxml.jackson.dataformat", version = "2.17." },
+  { groupId = "com.fasterxml.jackson.core", version = "2.18." },
+  { groupId = "com.fasterxml.jackson.dataformat", version = "2.18." },
   # https://github.com/akka/akka-http/pull/3995#issuecomment-1009951997
   { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." },
   # https://github.com/akka/akka-http/pull/3996#issuecomment-1009953070

--- a/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
+++ b/http-marshallers-java/http-jackson/src/main/java/org/apache/pekko/http/javadsl/marshallers/jackson/Jackson.java
@@ -107,6 +107,7 @@ public class Jackson {
             .maxStringLength(config.getInt("read.max-string-length"))
             .maxNameLength(config.getInt("read.max-name-length"))
             .maxDocumentLength(config.getLong("read.max-document-length"))
+            .maxTokenCount(config.getLong("read.max-token-count"))
             .build();
     StreamWriteConstraints streamWriteConstraints =
         StreamWriteConstraints.builder()
@@ -126,16 +127,14 @@ public class Jackson {
     switch (poolType) {
       case "thread-local":
         return JsonRecyclerPools.threadLocalPool();
-      case "lock-free":
-        return JsonRecyclerPools.newLockFreePool();
-      case "shared-lock-free":
-        return JsonRecyclerPools.sharedLockFreePool();
       case "concurrent-deque":
         return JsonRecyclerPools.newConcurrentDequePool();
       case "shared-concurrent-deque":
         return JsonRecyclerPools.sharedConcurrentDequePool();
       case "bounded":
         return JsonRecyclerPools.newBoundedPool(cfg.getInt("buffer-recycler.bounded-pool-size"));
+      case "non-recycling":
+        return JsonRecyclerPools.nonRecyclingPool();
       default:
         throw new IllegalArgumentException("Unknown recycler-pool: " + poolType);
     }

--- a/http-marshallers-java/http-jackson/src/main/resources/reference.conf
+++ b/http-marshallers-java/http-jackson/src/main/resources/reference.conf
@@ -9,7 +9,7 @@
 
 pekko.http.marshallers.jackson {
   read {
-    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.17.1/com/fasterxml/jackson/core/StreamReadConstraints.html
+    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.18.2/com/fasterxml/jackson/core/StreamReadConstraints.html
     # these defaults are the same as the defaults in `StreamReadConstraints`
     max-nesting-depth = 1000
     max-number-length = 1000
@@ -17,20 +17,21 @@ pekko.http.marshallers.jackson {
     max-name-length = 50000
     # max-document-length of -1 means unlimited
     max-document-length = -1
+    # max-token-count of -1 means unlimited
+    max-token-count = -1
   }
 
   write {
-    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.17.1/com/fasterxml/jackson/core/StreamWriteConstraints.html
+    # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.18.2/com/fasterxml/jackson/core/StreamWriteConstraints.html
     # these defaults are the same as the defaults in `StreamWriteConstraints`
     max-nesting-depth = 1000
   }
 
   # Controls the Buffer Recycler Pool implementation used by Jackson.
-  # https://javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.17.1/com/fasterxml/jackson/core/util/JsonRecyclerPools.html
-  # The default is "thread-local" which is the same as the default in Jackson 2.16.
+  # https://javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.18.2/com/fasterxml/jackson/core/util/JsonRecyclerPools.html
+  # The default is "thread-local" which is the same as the default in Jackson 2.18.
   buffer-recycler {
-    # the supported values are "thread-local", "lock-free", "shared-lock-free", "concurrent-deque",
-    # "shared-concurrent-deque", "bounded"
+    # the supported values are "thread-local", "concurrent-deque", "shared-concurrent-deque", "bounded", "non-recycling"
     pool-instance = "thread-local"
     # the maximum size of bounded recycler pools - must be >=1 or an IllegalArgumentException will occur
     # only applies to pool-instance type "bounded"

--- a/http-marshallers-java/http-jackson/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson/JacksonTest.java
+++ b/http-marshallers-java/http-jackson/src/test/java/org/apache/pekko/http/javadsl/marshallers/jackson/JacksonTest.java
@@ -94,6 +94,7 @@ public class JacksonTest extends JUnitRouteTest {
     final int maxNameLen = 54321;
     final int maxStringLen = 1234567;
     final long maxDocLen = 123456789L;
+    final long maxTokenCount = 9876543210L;
     final int maxNestingDepth = 5;
     String configText =
         "read.max-number-length="
@@ -108,6 +109,9 @@ public class JacksonTest extends JUnitRouteTest {
             + "read.max-document-length="
             + maxDocLen
             + "\n"
+            + "read.max-token-count="
+            + maxTokenCount
+            + "\n"
             + "read.max-nesting-depth="
             + maxNestingDepth;
     Config config = ConfigFactory.parseString(configText).withFallback(getDefaultConfig());
@@ -117,6 +121,7 @@ public class JacksonTest extends JUnitRouteTest {
     assertEquals(maxNameLen, constraints.getMaxNameLength());
     assertEquals(maxStringLen, constraints.getMaxStringLength());
     assertEquals(maxDocLen, constraints.getMaxDocumentLength());
+    assertEquals(maxTokenCount, constraints.getMaxTokenCount());
     assertEquals(maxNestingDepth, constraints.getMaxNestingDepth());
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val jacksonDatabindVersion = "2.17.3"
+  val jacksonDatabindVersion = "2.18.2"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
   val h2specVersion = "2.6.0"


### PR DESCRIPTION
see https://github.com/apache/pekko/pull/1556

need to document the removal of lock-free recycler pool option (Jackson abandoned this) and max-token-count