### PR TITLE
remove old scala steward settings

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -14,6 +14,8 @@ updates.pin = [
   # pin to jackson version used in pekko-core 
   { groupId = "com.fasterxml.jackson.core", version = "2.17." },
   { groupId = "com.fasterxml.jackson.dataformat", version = "2.17." },
+  # specs2 v5 needs newer java version
+  { groupId = "org.specs2", artifactId = "specs2-core", version = "4." },
   # https://github.com/akka/akka-http/pull/4080#issuecomment-1074853622
   { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine", version = "2.9." },
   # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -14,10 +14,6 @@ updates.pin = [
   # pin to jackson version used in pekko-core 
   { groupId = "com.fasterxml.jackson.core", version = "2.17." },
   { groupId = "com.fasterxml.jackson.dataformat", version = "2.17." },
-  # https://github.com/akka/akka-http/pull/3995#issuecomment-1009951997
-  { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." },
-  # https://github.com/akka/akka-http/pull/3996#issuecomment-1009953070
-  { groupId = "org.specs2", artifactId = "specs2-core", version = "4.10." },
   # https://github.com/akka/akka-http/pull/4080#issuecomment-1074853622
   { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine", version = "2.9." },
   # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11


### PR DESCRIPTION
we already use newer versions of scala-xml and specs2 than the scala steward pin is set to
* scala-xml 2.1.0: https://github.com/apache/pekko-http/blob/main/project/Dependencies.scala#L54
* specs2 4.20.3: https://github.com/apache/pekko-http/blob/main/project/Dependencies.scala#L81

