### PR TITLE
don't use `@Deprecated` when we also have `@deprecated`

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
@@ -60,14 +60,14 @@ object ConnectionContext {
 
   // ConnectionContext
   /** Used to serve HTTPS traffic. */
-  @Deprecated @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
+  @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(sslContext: SSLContext): HttpsConnectionContext = // ...
     // #https-context-creation
     scaladsl.ConnectionContext.https(sslContext)
 
   /** Used to serve HTTPS traffic. */
-  @Deprecated @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
+  @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(
       sslContext: SSLContext,
@@ -86,7 +86,7 @@ object ConnectionContext {
       sslParameters.toScala)
 
   /** Used to serve HTTPS traffic. */
-  @Deprecated @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
+  @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(
       sslContext: SSLContext,
@@ -126,22 +126,22 @@ abstract class HttpsConnectionContext extends pekko.http.javadsl.ConnectionConte
   override final def isSecure = true
 
   /** Java API */
-  @Deprecated @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
+  @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
   def getEnabledCipherSuites: Optional[JCollection[String]]
 
   /** Java API */
-  @Deprecated @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
+  @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
   def getEnabledProtocols: Optional[JCollection[String]]
 
   /** Java API */
-  @Deprecated @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
+  @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
   def getClientAuth: Optional[TLSClientAuth]
 
   /** Java API */
-  @Deprecated @deprecated("here for binary compatibility, not always available", since = "Akka HTTP 10.2.0")
+  @deprecated("here for binary compatibility, not always available", since = "Akka HTTP 10.2.0")
   def getSslContext: SSLContext
 
   /** Java API */
-  @Deprecated @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
+  @deprecated("here for binary compatibility", since = "Akka HTTP 10.2.0")
   def getSslParameters: Optional[SSLParameters]
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
@@ -59,14 +59,20 @@ object ConnectionContext {
     scaladsl.ConnectionContext.httpsClient((host, port) => createEngine(host, port))
 
   // ConnectionContext
-  /** Used to serve HTTPS traffic. */
+  /**
+    * Used to serve HTTPS traffic.
+    * @deprecated since Akka HTTP 10.2.0, use httpsServer, httpsClient or the method that takes a custom factory
+    */
   @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(sslContext: SSLContext): HttpsConnectionContext = // ...
     // #https-context-creation
     scaladsl.ConnectionContext.https(sslContext)
 
-  /** Used to serve HTTPS traffic. */
+  /**
+   * Used to serve HTTPS traffic.
+   * @deprecated since Akka HTTP 10.2.0, use httpsServer, httpsClient or the method that takes a custom factory
+   */
   @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(
@@ -85,7 +91,10 @@ object ConnectionContext {
       clientAuth.toScala,
       sslParameters.toScala)
 
-  /** Used to serve HTTPS traffic. */
+  /**
+   * Used to serve HTTPS traffic.
+   * @deprecated since Akka HTTP 10.2.0, use httpsServer, httpsClient or the method that takes a custom factory
+   */
   @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(
@@ -110,7 +119,6 @@ object ConnectionContext {
 @DoNotInherit
 abstract class ConnectionContext {
   def isSecure: Boolean
-  @Deprecated
   @deprecated("Not always available", since = "Akka HTTP 10.2.0")
   def sslConfig: Option[PekkoSSLConfig]
 }

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala
@@ -60,9 +60,9 @@ object ConnectionContext {
 
   // ConnectionContext
   /**
-    * Used to serve HTTPS traffic.
-    * @deprecated since Akka HTTP 10.2.0, use httpsServer, httpsClient or the method that takes a custom factory
-    */
+   * Used to serve HTTPS traffic.
+   * @deprecated since Akka HTTP 10.2.0, use httpsServer, httpsClient or the method that takes a custom factory
+   */
   @deprecated("use httpsServer, httpsClient or the method that takes a custom factory",
     since = "Akka HTTP 10.2.0")
   def https(sslContext: SSLContext): HttpsConnectionContext = // ...

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -820,22 +820,22 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
     delegate.setDefaultClientHttpsContext(context.asScala)
 
   /**
-    * @deprecated use ConnectionContext.httpsServer instead
-    */
+   * @deprecated use ConnectionContext.httpsServer instead
+   */
   @deprecated("use ConnectionContext.httpsServer", since = "Akka HTTP 10.2.0")
   def createServerHttpsContext(sslConfig: PekkoSSLConfig): HttpsConnectionContext =
     delegate.createServerHttpsContext(sslConfig)
 
   /**
-    * @deprecated use ConnectionContext.httpsClient instead
-    */
+   * @deprecated use ConnectionContext.httpsClient instead
+   */
   @deprecated("use ConnectionContext.httpsClient", since = "Akka HTTP 10.2.0")
   def createClientHttpsContext(sslConfig: PekkoSSLConfig): HttpsConnectionContext =
     delegate.createClientHttpsContext(sslConfig)
 
   /**
-    * @deprecated use ConnectionContext.httpsClient instead
-    */
+   * @deprecated use ConnectionContext.httpsClient instead
+   */
   @deprecated("use ConnectionContext.httpsClient", since = "Akka HTTP 10.2.0")
   def createDefaultClientHttpsContext(): HttpsConnectionContext =
     delegate.createDefaultClientHttpsContext()

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -119,7 +119,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).connectionSource() instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bind(connect: ConnectHttp): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
     val connectionContext = connect.effectiveConnectionContext(defaultServerHttpContext).asScala
@@ -145,7 +144,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).connectionSource() instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bind(
       connect: ConnectHttp,
@@ -174,7 +172,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).logTo(log).connectionSource() instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bind(
       connect: ConnectHttp,
@@ -199,7 +196,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).bindFlow(handler) instead.
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bindAndHandle(
       handler: Flow[HttpRequest, HttpResponse, _],
@@ -225,7 +221,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).logTo(log).bindFlow(handler) instead.
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bindAndHandle(
       handler: Flow[HttpRequest, HttpResponse, _],
@@ -253,7 +248,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).bindSync(handler) instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bindAndHandleSync(
       handler: pekko.japi.Function[HttpRequest, HttpResponse],
@@ -277,7 +271,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).logTo(log).bindSync(handler) instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bindAndHandleSync(
       handler: pekko.japi.Function[HttpRequest, HttpResponse],
@@ -305,7 +298,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).bind(handler) instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bindAndHandleAsync(
       handler: pekko.japi.Function[HttpRequest, CompletionStage[HttpResponse]],
@@ -329,7 +321,6 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).logTo(log).bind(handler) instead
    */
-  @Deprecated
   @deprecated("Use newServerAt instead", since = "Akka HTTP 10.2.0")
   def bindAndHandleAsync(
       handler: pekko.japi.Function[HttpRequest, CompletionStage[HttpResponse]],
@@ -828,14 +819,23 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
   def setDefaultClientHttpsContext(context: HttpsConnectionContext): Unit =
     delegate.setDefaultClientHttpsContext(context.asScala)
 
+  /**
+    * @deprecated use ConnectionContext.httpsServer instead
+    */
   @deprecated("use ConnectionContext.httpsServer", since = "Akka HTTP 10.2.0")
   def createServerHttpsContext(sslConfig: PekkoSSLConfig): HttpsConnectionContext =
     delegate.createServerHttpsContext(sslConfig)
 
+  /**
+    * @deprecated use ConnectionContext.httpsClient instead
+    */
   @deprecated("use ConnectionContext.httpsClient", since = "Akka HTTP 10.2.0")
   def createClientHttpsContext(sslConfig: PekkoSSLConfig): HttpsConnectionContext =
     delegate.createClientHttpsContext(sslConfig)
 
+  /**
+    * @deprecated use ConnectionContext.httpsClient instead
+    */
   @deprecated("use ConnectionContext.httpsClient", since = "Akka HTTP 10.2.0")
   def createDefaultClientHttpsContext(): HttpsConnectionContext =
     delegate.createDefaultClientHttpsContext()

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -803,7 +803,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: set context explicitly when binding
    */
-  @Deprecated @deprecated("Set context explicitly when binding", since = "Akka HTTP 10.2.0")
+  @deprecated("Set context explicitly when binding", since = "Akka HTTP 10.2.0")
   def defaultServerHttpContext: ConnectionContext =
     delegate.defaultServerHttpContext
 
@@ -813,7 +813,7 @@ class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
    *
    * @deprecated since Akka HTTP 10.2.0: set context explicitly when binding
    */
-  @Deprecated @deprecated("Set context explicitly when binding", since = "Akka HTTP 10.2.0")
+  @deprecated("Set context explicitly when binding", since = "Akka HTTP 10.2.0")
   def setDefaultServerHttpContext(context: ConnectionContext): Unit =
     delegate.setDefaultServerHttpContext(context.asScala)
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -31,7 +31,6 @@ import pekko.stream._
  *
  * @deprecated use the WebSocketUpgrade attribute instead since Akka HTTP 10.2.0
  */
-@Deprecated
 @deprecated("use the WebSocketUpgrade attribute instead", since = "Akka HTTP 10.2.0")
 trait UpgradeToWebSocket extends sm.HttpHeader with WebSocketUpgrade {
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ParserSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ParserSettings.scala
@@ -122,21 +122,18 @@ object ParserSettings extends SettingsCompanion[ParserSettings] {
   /**
    * @deprecated Use forServer or forClient instead.
    */
-  @Deprecated
   @deprecated("Use forServer or forClient instead", since = "Akka HTTP 10.2.0")
   override def create(config: Config): ParserSettings = ParserSettingsImpl(config)
 
   /**
    * @deprecated Use forServer or forClient instead.
    */
-  @Deprecated
   @deprecated("Use forServer or forClient instead", since = "Akka HTTP 10.2.0")
   override def create(configOverrides: String): ParserSettings = ParserSettingsImpl(configOverrides)
 
   /**
    * @deprecated Use forServer or forClient instead.
    */
-  @Deprecated
   @deprecated("Use forServer or forClient instead", since = "Akka HTTP 10.2.0")
   @nowarn("msg=create overrides concrete, non-deprecated symbol")
   override def create(system: ActorSystem): ParserSettings = create(system.settings.config)

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
@@ -53,6 +53,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getBacklog: Int
   def getSocketOptions: java.lang.Iterable[SocketOption]
   def getDefaultHostHeader: Host
+
   /**
    * @deprecated since Akka HTTP 10.2.0, use websocketSettings.getRandomFactory instead
    */
@@ -89,9 +90,10 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
     self.copy(socketOptions = newValue.asScala.toList)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue.asScala)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue.asScala)
+
   /**
-    * @deprecated since Akka HTTP 10.2.0, use websocketSettings.withRandomFactoryFactory instead
-    */
+   * @deprecated since Akka HTTP 10.2.0, use websocketSettings.withRandomFactoryFactory instead
+   */
   @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
     since = "Akka HTTP 10.2.0")
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
@@ -43,7 +43,6 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   /**
    * @deprecated since Akka HTTP 10.2.0, use remoteAddressAttribute instead
    */
-  @Deprecated
   @deprecated("Use remoteAddressAttribute instead", since = "Akka HTTP 10.2.0")
   def getRemoteAddressHeader: Boolean
   def getRemoteAddressAttribute: Boolean
@@ -54,6 +53,9 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getBacklog: Int
   def getSocketOptions: java.lang.Iterable[SocketOption]
   def getDefaultHostHeader: Host
+  /**
+   * @deprecated since Akka HTTP 10.2.0, use websocketSettings.getRandomFactory instead
+   */
   @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead",
     since = "Akka HTTP 10.2.0")
   def getWebsocketRandomFactory: java.util.function.Supplier[Random]
@@ -87,6 +89,9 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
     self.copy(socketOptions = newValue.asScala.toList)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue.asScala)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue.asScala)
+  /**
+    * @deprecated since Akka HTTP 10.2.0, use websocketSettings.withRandomFactoryFactory instead
+    */
   @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
     since = "Akka HTTP 10.2.0")
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
@@ -54,7 +54,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getBacklog: Int
   def getSocketOptions: java.lang.Iterable[SocketOption]
   def getDefaultHostHeader: Host
-  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead",
+  @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead",
     since = "Akka HTTP 10.2.0")
   def getWebsocketRandomFactory: java.util.function.Supplier[Random]
   def getWebsocketSettings: WebSocketSettings
@@ -87,7 +87,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
     self.copy(socketOptions = newValue.asScala.toList)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue.asScala)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue.asScala)
-  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
+  @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
     since = "Akka HTTP 10.2.0")
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings =
     self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
@@ -56,7 +56,7 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   def backlog: Int
   def socketOptions: immutable.Seq[SocketOption]
   def defaultHostHeader: Host
-  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.randomFactory instead",
+  @deprecated("Kept for binary compatibility; Use websocketSettings.randomFactory instead",
     since = "Akka HTTP 10.1.1")
   def websocketRandomFactory: () => Random
   def websocketSettings: WebSocketSettings
@@ -87,7 +87,7 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   override def getRemoteAddressHeader = this.remoteAddressHeader
   override def getRemoteAddressAttribute: Boolean = this.remoteAddressAttribute
   override def getLogUnencryptedNetworkBytes = this.logUnencryptedNetworkBytes.toJava
-  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead",
+  @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead",
     since = "Akka HTTP 10.2.0")
   override def getWebsocketRandomFactory = new Supplier[Random] {
     override def get(): Random = self.websocketRandomFactory()
@@ -116,7 +116,7 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   override def withBacklog(newValue: Int): ServerSettings = self.copy(backlog = newValue)
   override def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ServerSettings =
     self.copy(socketOptions = newValue.asScala.toList)
-  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
+  @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
     since = "Akka HTTP 10.2.0")
   override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings =
     self.copy(websocketSettings = this.websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
@@ -139,7 +139,7 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
     self.copy(logUnencryptedNetworkBytes = newValue)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue)
-  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
+  @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead",
     since = "Akka HTTP 10.2.0")
   def withWebsocketRandomFactory(newValue: () => Random): ServerSettings =
     self.copy(websocketSettings = this.websocketSettings.withRandomFactoryFactory(new Supplier[Random] {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
@@ -35,6 +35,9 @@ object Directives extends AllDirectives {
   // signatures for varargs methods, making them show up as Seq<Object> instead of T... in Java.
 
   // deprecated in https://github.com/apache/pekko-http/commit/fffca8de9f6a6237788021a2e3fa49a95463a8c6
+  /**
+    * @deprecated since Akka HTTP 10.2.0, use RouteDirectives.concat instead.
+    */
   @deprecated("Use the RouteDirectives.concat method instead.", since = "Akka HTTP 10.2.0")
   @varargs
   @nowarn("msg=route in class RouteDirectives is deprecated")

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
@@ -35,7 +35,7 @@ object Directives extends AllDirectives {
   // signatures for varargs methods, making them show up as Seq<Object> instead of T... in Java.
 
   // deprecated in https://github.com/apache/pekko-http/commit/fffca8de9f6a6237788021a2e3fa49a95463a8c6
-  @deprecated("Use the RouteDirectives.concat method instead." since = "Akka HTTP 10.2.0")
+  @deprecated("Use the RouteDirectives.concat method instead.", since = "Akka HTTP 10.2.0")
   @varargs
   @nowarn("msg=route in class RouteDirectives is deprecated")
   override def route(alternatives: Route*): Route =

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
@@ -36,8 +36,8 @@ object Directives extends AllDirectives {
 
   // deprecated in https://github.com/apache/pekko-http/commit/fffca8de9f6a6237788021a2e3fa49a95463a8c6
   /**
-    * @deprecated since Akka HTTP 10.2.0, use RouteDirectives.concat instead.
-    */
+   * @deprecated since Akka HTTP 10.2.0, use RouteDirectives.concat instead.
+   */
   @deprecated("Use the RouteDirectives.concat method instead.", since = "Akka HTTP 10.2.0")
   @varargs
   @nowarn("msg=route in class RouteDirectives is deprecated")

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
@@ -34,7 +34,8 @@ object Directives extends AllDirectives {
   // These are repeated here since sometimes (?) the Scala compiler won't actually generate java-compatible
   // signatures for varargs methods, making them show up as Seq<Object> instead of T... in Java.
 
-  @Deprecated
+  // deprecated in https://github.com/apache/pekko-http/commit/fffca8de9f6a6237788021a2e3fa49a95463a8c6
+  @deprecated("Use the RouteDirectives.concat method instead." since = "Akka HTTP 10.2.0")
   @varargs
   @nowarn("msg=route in class RouteDirectives is deprecated")
   override def route(alternatives: Route*): Route =

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
@@ -53,7 +53,6 @@ abstract class RouteDirectives extends RespondWithDirectives {
    * rather than having to explicitly call route1.orElse(route2).orElse(route3).
    * @deprecated Use the `RouteDirectives.concat` method instead.
    */
-  @Deprecated
   @deprecated("Use the RouteDirectives.concat method instead.", "Akka HTTP 10.1.6")
   @CorrespondsTo("concat")
   @varargs def route(alternatives: Route*): Route = RouteAdapter {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/WebSocketDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/WebSocketDirectives.scala
@@ -36,7 +36,6 @@ abstract class WebSocketDirectives extends SecurityDirectives {
    *
    * @deprecated use `webSocketUpgrade` instead since Akka HTTP 10.2.0
    */
-  @Deprecated
   @deprecated("use `extractWebSocketUpgrade` instead", since = "Akka HTTP 10.2.0")
   def extractUpgradeToWebSocket(inner: JFunction[UpgradeToWebSocket, Route]): Route = RouteAdapter {
     D.extractUpgradeToWebSocket { header =>

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
@@ -33,7 +33,6 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
-  @Deprecated
   def getFileIODispatcher: String
 
   def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings =
@@ -51,7 +50,6 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
-  @Deprecated
   def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self
 }
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
@@ -30,9 +30,10 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def getRangeCountLimit: Int
   def getRangeCoalescingThreshold: Long
   def getDecodeMaxBytesPerChunk: Int
+
   /**
-    * @deprecated since Akka HTTP 10.1.6, use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher
-    */
+   * @deprecated since Akka HTTP 10.1.6, use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher
+   */
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
@@ -50,9 +51,10 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings =
     self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
+
   /**
-    * @deprecated since Akka HTTP 10.1.6, use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher
-    */
+   * @deprecated since Akka HTTP 10.1.6, use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher
+   */
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
@@ -30,6 +30,9 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def getRangeCountLimit: Int
   def getRangeCoalescingThreshold: Long
   def getDecodeMaxBytesPerChunk: Int
+  /**
+    * @deprecated since Akka HTTP 10.1.6, use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher
+    */
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
@@ -47,6 +50,9 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings =
     self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
+  /**
+    * @deprecated since Akka HTTP 10.1.6, use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher
+    */
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
@@ -47,7 +47,6 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
-  @Deprecated
   def getFileIODispatcher: String = this.fileIODispatcher
 
   override def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings =
@@ -65,7 +64,6 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   @deprecated(
     "binary compatibility method. Use `pekko.stream.materializer.blocking-io-dispatcher` to configure the dispatcher",
     since = "Akka HTTP 10.1.6")
-  @Deprecated
   override def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self
 }
 


### PR DESCRIPTION
relates to #714 

We get a lot of compiler warnings due to this.

Example
```
[warn] /home/code/pekko-http/http-core/src/main/scala/org/apache/pekko/http/javadsl/ConnectionContext.scala:115:4: Prefer the Scala annotation over Java's `@Deprecated` to provide a message and version: @deprecated("message", since = "MyLib 1.0")
```