### PR TITLE
stop using deprecated method Flow.lazyInitAsync

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
@@ -147,13 +147,13 @@ object ClientTransport {
       }.mapMaterializedValue(_.flatten)
     }
 
-    // TODO: replace with lazyFutureFlow when support for Akka 2.5.x is dropped
     private def initFutureFlow[M](flowFactory: () => Future[Flow[ByteString, ByteString, M]])(
         implicit ec: ExecutionContext): Flow[ByteString, ByteString, Future[M]] = {
       Flow[ByteString].prepend(Source.single(ByteString()))
         .viaMat(
-          Flow.lazyInitAsync(flowFactory)
-            .mapMaterializedValue(_.map(_.get))
+          Flow.lazyFutureFlow(flowFactory)
+            //.prefixAndTail(1)
+            //.mapMaterializedValue(_.map(_.get))
             // buffer needed because HTTP client expects demand before it does request (which is reasonable for buffered TCP connections)
             .buffer(1, OverflowStrategy.backpressure))(Keep.right)
     }

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ClientTransport.scala
@@ -152,8 +152,6 @@ object ClientTransport {
       Flow[ByteString].prepend(Source.single(ByteString()))
         .viaMat(
           Flow.lazyFutureFlow(flowFactory)
-            //.prefixAndTail(1)
-            //.mapMaterializedValue(_.map(_.get))
             // buffer needed because HTTP client expects demand before it does request (which is reasonable for buffered TCP connections)
             .buffer(1, OverflowStrategy.backpressure))(Keep.right)
     }


### PR DESCRIPTION
pekko 2.0.0 removes a lot of deprecated methods and it would be nice to tidy up pekko-http to avoid such methods