### PR TITLE
add missing Deprecated annotation

### DIFF
--- a/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/HttpCookie.java
+++ b/http-core/src/main/java/org/apache/pekko/http/javadsl/model/headers/HttpCookie.java
@@ -78,6 +78,7 @@ public abstract class HttpCookie {
    * @deprecated Since Akka HTTP 10.2.0. Use {@link #create(String, String, Optional, OptionalLong,
    *     Optional, Optional, boolean, boolean, Optional, Optional)} instead.
    */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public static HttpCookie create(
       String name,


### PR DESCRIPTION
causes a build warning when missing