### PR TITLE
remove `final object`

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ConnectionContext.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/ConnectionContext.scala
@@ -171,7 +171,7 @@ sealed class HttpConnectionContext extends pekko.http.javadsl.HttpConnectionCont
   protected[http] override final def defaultPort: Int = 80
 }
 
-final object HttpConnectionContext extends HttpConnectionContext {
+object HttpConnectionContext extends HttpConnectionContext {
 
   /** Java API */
   def getInstance() = this

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -243,7 +243,7 @@ class HeaderDirectivesSpec extends RoutingSpec with Inside {
 }
 
 object HeaderDirectivesSpec {
-  final object XCustomHeader extends ModeledCustomHeaderCompanion[XCustomHeader] {
+  object XCustomHeader extends ModeledCustomHeaderCompanion[XCustomHeader] {
     override def name: String = "X-Custom-Header"
     override def parse(value: String): Try[XCustomHeader] = Try(new XCustomHeader)
   }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
@@ -26,7 +26,7 @@ import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 @InternalApi
 private object ServerSentEventParser {
 
-  final object PosInt {
+  object PosInt {
     def unapply(s: String): Option[Int] =
       try { Some(s.trim.toInt) }
       catch { case _: NumberFormatException => None }


### PR DESCRIPTION
* Scala 3 compiler gives a compiler warning

```
Modifier final is redundant for this definition
```