### PR TITLE
remove withFuzzing call in tests

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TestServer.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TestServer.scala
@@ -43,7 +43,6 @@ object TestServer extends App {
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
 
   val settings = ActorMaterializerSettings(system)
-    .withFuzzing(false)
     //    .withSyncProcessingLimit(Int.MaxValue)
     .withInputBuffer(128, 128)
   implicit val fm: ActorMaterializer = ActorMaterializer(settings)


### PR DESCRIPTION
The fuzzing setting is set in the config - so this is not needed.
The API is deprecated and is being removed.
