### PR TITLE
avoid Scala classes in Java example

### DIFF
--- a/http-core/src/test/java/org/apache/pekko/http/javadsl/WSEchoTestClientApp.java
+++ b/http-core/src/test/java/org/apache/pekko/http/javadsl/WSEchoTestClientApp.java
@@ -55,10 +55,7 @@ public class WSEchoTestClientApp {
           CompletableFuture.completedFuture((Message) TextMessage.create("blub"));
       final CompletionStage<Message> delayedCompletion =
           org.apache.pekko.pattern.Patterns.after(
-              Duration.ofSeconds(1),
-              system.scheduler(),
-              system.dispatcher(),
-              () -> ignoredMessage);
+              Duration.ofSeconds(1), system.scheduler(), system.dispatcher(), () -> ignoredMessage);
 
       Source<Message, NotUsed> echoSource =
           Source.from(


### PR DESCRIPTION
Pekko 2 removes some of the Scala class support for the Java DSL to encourage Pure Java usages instead