### PR TITLE
Update PEKKO_VERSION in nightly workflow due to build issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3]
         JDK: [8, 11, 17, 21]
-        PEKKO_VERSION: ['default', 'main', '1.0.x']
+        PEKKO_VERSION: ['default', '1.0.x', '1.2.x']
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
* Due to breaking changes in main branch of Pekko aimed at the 2.0.0 release, we have failures in nightly build.
* The 'default' tests with the 1.1.5 release, '1.0.x' tests with the latest 1.0.x snapshot
* Let's test the latest 1.2.s snapshots