### PR TITLE
protect 1.3.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,6 +48,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.3.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
     1.2.x:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".


### PR DESCRIPTION
There are some changes in https://github.com/apache/pekko-http/milestone/9 but a 1.3.0 doesn't yet seem urgent.
We can release 1.3.0 from the 1.3.x branch when needed.

There are already PRs targeting 2.0.x and it would be nice to start merging them.
https://github.com/apache/pekko-http/milestone/11