### PR TITLE
deprecate withRemoteAddressHeader

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
@@ -76,6 +76,11 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue.asScala)
   def withMaxConnections(newValue: Int): ServerSettings = self.copy(maxConnections = newValue)
   def withPipeliningLimit(newValue: Int): ServerSettings = self.copy(pipeliningLimit = newValue)
+  /**
+   * @deprecated since Pekko HTTP 1.3.0, use withRemoteAddressAttribute instead
+   */
+  @Deprecated
+  @deprecated("Use withRemoteAddressAttribute instead", since = "1.3.0")
   def withRemoteAddressHeader(newValue: Boolean): ServerSettings = self.copy(remoteAddressHeader = newValue)
   def withRemoteAddressAttribute(newValue: Boolean): ServerSettings = self.copy(remoteAddressAttribute = newValue)
   def withRawRequestUriHeader(newValue: Boolean): ServerSettings = self.copy(rawRequestUriHeader = newValue)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
@@ -105,6 +105,11 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
     self.copy(previewServerSettings = newValue)
   override def withMaxConnections(newValue: Int): ServerSettings = self.copy(maxConnections = newValue)
   override def withPipeliningLimit(newValue: Int): ServerSettings = self.copy(pipeliningLimit = newValue)
+  /**
+   * @deprecated since Pekko HTTP 1.3.0, use withRemoteAddressAttribute instead
+   */
+  @Deprecated
+  @deprecated("Use withRemoteAddressAttribute instead", since = "1.3.0")
   override def withRemoteAddressHeader(newValue: Boolean): ServerSettings = self.copy(remoteAddressHeader = newValue)
   override def withRemoteAddressAttribute(newValue: Boolean): ServerSettings =
     self.copy(remoteAddressAttribute = newValue)

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
@@ -1168,6 +1168,7 @@ class HttpServerSpec extends PekkoSpec(
       // coverage for #21130
       lazy val theAddress = InetAddress.getByName("127.5.2.1")
 
+      @nowarn("msg=deprecated")
       override def settings: ServerSettings =
         super.settings.withRemoteAddressHeader(true)
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
@@ -221,6 +221,7 @@ abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMateria
       }
 
       abstract class RemoteAddressTestScenario {
+        @nowarn("msg=deprecated")
         val settings = ServerSettings(system).withRemoteAddressHeader(true)
         def createBinding(): Future[ServerBinding]
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/PreviewServerSettingsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/PreviewServerSettingsSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.scaladsl.settings
 
 import org.apache.pekko.testkit.PekkoSpec
 
+@nowarn("msg=deprecated")
 class PreviewServerSettingsSpec extends PekkoSpec {
 
   def compileOnlySpec(body: => Unit) = ()


### PR DESCRIPTION
* see #757 
* this is a patch to deprecate the methods in 1.3.0 while 757 removes them in 2.0.0