### PR TITLE
experiment with using remote address attributes

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
@@ -219,7 +219,7 @@ abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMateria
       }
 
       abstract class RemoteAddressTestScenario {
-        val settings = ServerSettings(system).withRemoteAddressHeader(true)
+        val settings = ServerSettings(system).withRemoteAddressAttribute(true)
         def createBinding(): Future[ServerBinding]
 
         val binding = createBinding()

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/PreviewServerSettingsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/settings/PreviewServerSettingsSpec.scala
@@ -23,7 +23,7 @@ class PreviewServerSettingsSpec extends PekkoSpec {
     "compile when set programmatically" in compileOnlySpec {
       ServerSettings(system)
         .withPreviewServerSettings(PreviewServerSettings(system).withEnableHttp2(true))
-        .withRemoteAddressHeader(true)
+        .withRemoteAddressAttribute(true)
     }
     "work get right defaults" in {
       val it: PreviewServerSettings = PreviewServerSettings(system)


### PR DESCRIPTION
The server setting for remote address headers is deprecated (just on the get side - not on the setting side).
The suggestion is to use remote address attributes instead. However, request attributes and headers are not the same thing. So far, it seems like it would make sense to continue to support remote address headers.