### PR TITLE
don't use pekko.dispatch.ExecutionContexts

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/directives/BasicDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/BasicDirectivesExamplesTest.java
@@ -15,7 +15,6 @@ package docs.http.javadsl.server.directives;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.dispatch.ExecutionContexts;
 import org.apache.pekko.event.Logging;
 import org.apache.pekko.event.LoggingAdapter;
 import org.apache.pekko.http.javadsl.model.ContentTypes;
@@ -40,6 +39,7 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.Ignore;
 import org.junit.Test;
+import scala.concurrent.ExecutionContext;
 import scala.concurrent.ExecutionContextExecutor;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -354,7 +354,7 @@ public class BasicDirectivesExamplesTest extends JUnitRouteTest {
     // #withExecutionContext
 
     final ExecutionContextExecutor special =
-        ExecutionContexts.fromExecutor(Executors.newFixedThreadPool(1));
+        ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1));
 
     final Route sample =
         path(

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -140,8 +140,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import pekko.http.scaladsl.model._
     import pekko.http.scaladsl.model.HttpMessage.DiscardedEntity
 
-    import scala.concurrent.ExecutionContext
-
     implicit val system: ActorSystem = ActorSystem()
     implicit val dispatcher: ExecutionContext = system.dispatcher
 

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample.scala
@@ -27,10 +27,9 @@ import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
 
-import scala.io.StdIn
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.io.StdIn
 
 object SprayJsonExample {
 

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.CountDownLatch
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
-import pekko.dispatch.ExecutionContexts
 import pekko.http.CommonBenchmark
 import pekko.http.impl.util.enhanceString_
 import pekko.http.scaladsl.model.HttpRequest
@@ -57,7 +56,7 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
         .onComplete {
           case Success(_) => latch.countDown()
           case Failure(_) => throw new IllegalStateException
-        }(ExecutionContexts.parasitic)
+        }(ExecutionContext.parasitic)
     }
 
     latch.await()

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HttpEntityBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HttpEntityBenchmark.scala
@@ -17,13 +17,14 @@ import java.util.concurrent.CountDownLatch
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
-import pekko.dispatch.ExecutionContexts
 import pekko.http.CommonBenchmark
 import pekko.http.scaladsl.model.{ ContentTypes, HttpEntity }
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations.{ Benchmark, Param, Setup, TearDown }
+
+import scala.concurrent.ExecutionContext
 
 class HttpEntityBenchmark extends CommonBenchmark {
   @Param(Array("strict", "default"))
@@ -38,7 +39,7 @@ class HttpEntityBenchmark extends CommonBenchmark {
     val latch = new CountDownLatch(1)
     entity.discardBytes(system)
       .future
-      .onComplete(_ => latch.countDown())(ExecutionContexts.parasitic)
+      .onComplete(_ => latch.countDown())(ExecutionContext.parasitic)
     latch.await()
   }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolInterface.scala
@@ -37,9 +37,7 @@ import pekko.stream.stage.TimerGraphStageLogic
 import pekko.stream.{ BufferOverflowException, Materializer }
 
 import java.util
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/PoolMasterActor.scala
@@ -26,15 +26,12 @@ import pekko.actor.{
   Props
 }
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.http.impl.engine.client.PoolInterface.ShutdownReason
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import pekko.stream.Materializer
 
-import scala.concurrent.{ Future, Promise }
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.util.{ Failure, Success, Try }
 
 /**
  * INTERNAL API
@@ -191,7 +188,7 @@ private[http] final class PoolMasterActor extends Actor with ActorLogging {
           // has completed.
           val completed = pool.shutdown()(context.dispatcher)
           shutdownCompletedPromise.tryCompleteWith(
-            completed.map(_ => Done)(ExecutionContexts.parasitic))
+            completed.map(_ => Done)(ExecutionContext.parasitic))
           statusById += poolId -> PoolInterfaceShuttingDown(shutdownCompletedPromise)
         case Some(PoolInterfaceShuttingDown(formerPromise)) =>
           // Pool is already shutting down, mirror the existing promise.

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -20,7 +20,6 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.Cancellable
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.http.impl.engine.client.PoolFlow.{ RequestContext, ResponseContext }
 import pekko.http.impl.engine.client.pool.SlotState._
@@ -33,7 +32,7 @@ import pekko.stream._
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.control.{ NoStackTrace, NonFatal }
@@ -469,7 +468,7 @@ private[client] object NewHostConnectionPool {
                   entityComplete.onComplete(safely {
                     case Success(_)     => withSlot(_.onRequestEntityCompleted())
                     case Failure(cause) => withSlot(_.onRequestEntityFailed(cause))
-                  })(ExecutionContexts.parasitic)
+                  })(ExecutionContext.parasitic)
                   request.withEntity(newEntity)
               }
 
@@ -524,9 +523,9 @@ private[client] object NewHostConnectionPool {
                       ongoingResponseEntity = None
                       ongoingResponseEntityKillSwitch = None
                     }
-                  }(ExecutionContexts.parasitic)
+                  }(ExecutionContext.parasitic)
                 case Failure(_) => throw new IllegalStateException("Should never fail")
-              })(ExecutionContexts.parasitic)
+              })(ExecutionContext.parasitic)
 
               withSlot(_.onResponseReceived(response.withEntity(newEntity)))
             }
@@ -609,7 +608,7 @@ private[client] object NewHostConnectionPool {
                 onConnectionAttemptFailed(currentEmbargoLevel)
                 sl.onConnectionAttemptFailed(cause)
               }
-          })(ExecutionContexts.parasitic)
+          })(ExecutionContext.parasitic)
 
           slotCon
         }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/Http2.scala
@@ -23,7 +23,6 @@ import pekko.actor.{
   ExtensionIdProvider
 }
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.http.impl.engine.HttpConnectionIdleTimeoutBidi
 import pekko.http.impl.engine.server.{
@@ -51,7 +50,7 @@ import pekko.Done
 
 import javax.net.ssl.SSLEngine
 import scala.collection.immutable
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
@@ -125,7 +124,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
                 // See https://github.com/akka/akka/issues/17992
                 case NonFatal(ex) =>
                   Done
-              }(ExecutionContexts.parasitic)
+              }(ExecutionContext.parasitic)
           } catch {
             case NonFatal(e) =>
               log.error(e, "Could not materialize handling flow for {}", incoming)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
@@ -18,7 +18,6 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.http.impl.engine.http2.client.PersistentConnection
 import pekko.http.scaladsl.Http.OutgoingConnection
@@ -34,7 +33,7 @@ import pekko.http.scaladsl.HttpsConnectionContext
 import pekko.http.scaladsl.OutgoingConnectionBuilder
 import pekko.stream.javadsl.{ Flow => JFlow }
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * INTERNAL API
@@ -161,7 +160,7 @@ private[pekko] object OutgoingConnectionBuilderImpl {
         : JFlow[javadsl.model.HttpRequest, javadsl.model.HttpResponse, CompletionStage[javadsl.OutgoingConnection]] = {
       import pekko.util.FutureConverters._
       javaFlowKeepMatVal(flow.mapMaterializedValue(f =>
-        f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContexts.parasitic).asJava))
+        f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContext.parasitic).asJava))
     }
 
     private def javaFlowKeepMatVal[M](

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/client/PersistentConnection.scala
@@ -16,7 +16,6 @@ package org.apache.pekko.http.impl.engine.http2.client
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.http.scaladsl.Http.OutgoingConnection
 import pekko.http.scaladsl.model.{ AttributeKey, HttpRequest, HttpResponse, RequestResponseAssociation, StatusCodes }
 import pekko.http.scaladsl.settings.Http2ClientSettings
@@ -27,10 +26,8 @@ import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet, StreamTcpException }
 import pekko.util.PrettyDuration
 
 import java.util.concurrent.ThreadLocalRandom
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.DurationLong
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration.{ Duration, DurationLong, FiniteDuration }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.{ Failure, Success }
 
 /** INTERNAL API */
@@ -117,7 +114,7 @@ private[http2] object PersistentConnection {
               onConnected.invoke(())
             case Failure(cause) =>
               onFailed.invoke(cause)
-          }(ExecutionContexts.parasitic)
+          }(ExecutionContext.parasitic)
 
           var requestOutPulled = false
           requestOut.setHandler(new OutHandler {

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/server/HttpServerBluePrint.scala
@@ -22,7 +22,6 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.Cancellable
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.japi.function.Function
 import pekko.event.LoggingAdapter
 import pekko.http.ParsingErrorHandler
@@ -49,6 +48,7 @@ import pekko.http.javadsl.model
 import pekko.http.scaladsl.model._
 import pekko.http.impl.util.LogByteStringTools._
 
+import scala.concurrent.ExecutionContext
 import scala.util.Failure
 
 /**
@@ -496,7 +496,7 @@ private[http] object HttpServerBluePrint {
                       log.error(ex,
                         s"Response stream for [${requestStart.debugString}] failed with '${ex.getMessage}'. Aborting connection.")
                     case _ => // ignore
-                  }(ExecutionContexts.parasitic)
+                  }(ExecutionContext.parasitic)
                   newEntity
                 }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StreamUtils.scala
@@ -17,7 +17,6 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.Cancellable
 import pekko.annotation.InternalApi
-import pekko.dispatch.ExecutionContexts
 import pekko.http.scaladsl.model.HttpEntity
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream._
@@ -89,7 +88,7 @@ private[http] object StreamUtils {
             killResult.future.value match {
               case Some(res) => handleKill(res)
               case None =>
-                killResult.future.onComplete(killCallback.invoke)(ExecutionContexts.parasitic)
+                killResult.future.onComplete(killCallback.invoke)(ExecutionContext.parasitic)
             }
           }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -47,7 +47,7 @@ object Http extends ExtensionId[Http] with ExtensionIdProvider {
 }
 
 class Http(system: ExtendedActorSystem) extends pekko.actor.Extension {
-  import pekko.dispatch.ExecutionContexts.{ parasitic => ec }
+  import scala.concurrent.ExecutionContext.{ parasitic => ec }
 
   import language.implicitConversions
   private implicit def completionStageCovariant[T, U >: T](in: CompletionStage[T]): CompletionStage[U] =

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
@@ -18,13 +18,13 @@ import java.util.concurrent.{ CompletionStage, TimeUnit }
 
 import org.apache.pekko
 import pekko.Done
+import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.DoNotInherit
-import pekko.dispatch.ExecutionContexts
 import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-import pekko.actor.ClassicActorSystemProvider
 
 /**
  * Represents a prospective HTTP server binding.
@@ -89,7 +89,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
 
   def terminate(hardDeadline: java.time.Duration): CompletionStage[HttpTerminated] = {
     delegate.terminate(FiniteDuration.apply(hardDeadline.toMillis, TimeUnit.MILLISECONDS))
-      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
+      .map(_.asInstanceOf[HttpTerminated])(ExecutionContext.parasitic)
       .asJava
   }
 
@@ -103,7 +103,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
    */
   def whenTerminationSignalIssued: CompletionStage[java.time.Duration] =
     delegate.whenTerminationSignalIssued
-      .map(deadline => deadline.time.asJava)(ExecutionContexts.parasitic)
+      .map(deadline => deadline.time.asJava)(ExecutionContext.parasitic)
       .asJava
 
   /**
@@ -120,7 +120,7 @@ class ServerBinding private[http] (delegate: pekko.http.scaladsl.Http.ServerBind
    */
   def whenTerminated: CompletionStage[HttpTerminated] =
     delegate.whenTerminated
-      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
+      .map(_.asInstanceOf[HttpTerminated])(ExecutionContext.parasitic)
       .asJava
 
   /**

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
@@ -17,7 +17,6 @@ import java.util.concurrent.CompletionStage
 
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
-import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model.{ HttpRequest, HttpResponse }
@@ -195,6 +194,6 @@ object ServerBuilder {
     def connectionSource(): Source[IncomingConnection, CompletionStage[ServerBinding]] =
       http.bindImpl(interface, port, context.asScala, settings.asScala, log)
         .map(new IncomingConnection(_))
-        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.parasitic).asJava).asJava
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContext.parasitic).asJava).asJava
   }
 }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -100,7 +100,7 @@ class WebSocketIntegrationSpec extends PekkoSpecWithMaterializer(
 
               override def preStart(): Unit = {
                 promise.future.foreach(_ => getAsyncCallback[Done](_ => complete(shape.out)).invoke(Done))(
-                  pekko.dispatch.ExecutionContexts.parasitic)
+                  scala.concurrent.ExecutionContext.parasitic)
               }
 
               setHandlers(shape.in, shape.out, this)

--- a/http-marshallers-scala/http-spray-json/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/http-marshallers-scala/http-spray-json/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -22,9 +22,9 @@ import pekko.http.scaladsl.model.MessageEntity
 import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
-import spray.json.{ JsArray, JsString, JsValue }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import spray.json.{ JsArray, JsString, JsValue }
 import spray.json.RootJsonFormat
 
 class SprayJsonSupportSpec extends AnyWordSpec with Matchers with ScalaFutures {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -17,7 +17,6 @@ import java.util.function.{ Function => JFunction }
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
-import pekko.dispatch.ExecutionContexts
 import pekko.event.LoggingAdapter
 import pekko.japi.Util
 import pekko.stream.Materializer
@@ -46,7 +45,7 @@ import java.util.{ List => JList }
 import java.util.concurrent.CompletionStage
 import java.util.function.Predicate
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 import scala.concurrent.duration.FiniteDuration
 
 abstract class BasicDirectives {
@@ -99,8 +98,8 @@ abstract class BasicDirectives {
       inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultFuture(stage =>
       CompletionStageOps(
-        f(stage.fast.map(_.asJava)(ExecutionContexts.parasitic).asJava)).asScala.fast.map(_.asScala)(
-        ExecutionContexts.parasitic)) {
+        f(stage.fast.map(_.asJava)(ExecutionContext.parasitic).asJava)).asScala.fast.map(_.asScala)(
+        ExecutionContext.parasitic)) {
       inner.get.delegate
     }
   }
@@ -108,7 +107,7 @@ abstract class BasicDirectives {
   def mapRouteResultWith(f: JFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route =
     RouteAdapter {
       D.mapRouteResultWith(r =>
-        CompletionStageOps(f(r.asJava)).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
+        CompletionStageOps(f(r.asJava)).asScala.fast.map(_.asScala)(ExecutionContext.parasitic)) {
         inner.get.delegate
       }
     }
@@ -116,7 +115,7 @@ abstract class BasicDirectives {
   def mapRouteResultWithPF(
       f: PartialFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultWith(r =>
-      CompletionStageOps(f(r.asJava)).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
+      CompletionStageOps(f(r.asJava)).asScala.fast.map(_.asScala)(ExecutionContext.parasitic)) {
       inner.get.delegate
     }
   }
@@ -175,7 +174,7 @@ abstract class BasicDirectives {
       f: JFunction[JIterable[Rejection], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.recoverRejectionsWith(rs =>
       CompletionStageOps(f.apply(Util.javaArrayList(rs.map(_.asJava)))).asScala.fast.map(_.asScala)(
-        ExecutionContexts.parasitic)) { inner.get.delegate }
+        ExecutionContext.parasitic)) { inner.get.delegate }
   }
 
   /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
@@ -21,13 +21,13 @@ import java.util.function.Supplier
 import org.apache.pekko
 import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.RequestEntity
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Try
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.directives.{ CompleteOrRecoverWithMagnet, FutureDirectives => D }
 import pekko.pattern.CircuitBreaker
 import pekko.util.FutureConverters._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
 
 abstract class FutureDirectives extends FormFieldDirectives {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteDirectives.scala
@@ -15,12 +15,12 @@ package org.apache.pekko.http.javadsl.server.directives
 
 import java.util.concurrent.{ CompletionException, CompletionStage }
 
-import org.apache.pekko
-import pekko.dispatch.ExecutionContexts
-import pekko.http.javadsl.marshalling.Marshaller
-
 import scala.annotation.varargs
+import scala.concurrent.ExecutionContext
+
+import org.apache.pekko
 import pekko.http.impl.model.JavaUri
+import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.{
   HttpHeader,
   HttpRequest,
@@ -31,22 +31,21 @@ import pekko.http.javadsl.model.{
   Uri
 }
 import pekko.http.javadsl.server.{ Rejection, Route, RoutingJavaMapping }
+import pekko.http.javadsl.server.RoutingJavaMapping._
 import pekko.http.scaladsl
 import pekko.http.scaladsl.marshalling.Marshaller._
 import pekko.http.scaladsl.marshalling.ToResponseMarshallable
 import pekko.http.scaladsl.model.StatusCodes.Redirection
-import pekko.http.javadsl.server.RoutingJavaMapping._
 import pekko.http.scaladsl.server.RouteResult
 import pekko.http.scaladsl.server.directives.{ RouteDirectives => D }
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
-import scala.concurrent.ExecutionContext
 
 abstract class RouteDirectives extends RespondWithDirectives {
   import RoutingJavaMapping.Implicits._
 
   // Don't try this at home – we only use it here for the java -> scala conversions
-  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContexts.parasitic
+  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContext.parasitic
 
   /**
    * Java-specific call added so you can chain together multiple alternate routes using comma,

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -34,8 +34,8 @@ import pekko.util.ByteString
 import pekko.util.FutureConverters._
 
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
 
 object Unmarshaller extends pekko.http.javadsl.unmarshalling.Unmarshallers {
   implicit def fromScala[A, B](scalaUnmarshaller: unmarshalling.Unmarshaller[A, B]): Unmarshaller[A, B] =


### PR DESCRIPTION
with Scala 2.12 support removed, we can use Scala methods directly