### PR TITLE
use Scala Future Converters

### DIFF
--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
@@ -19,6 +19,7 @@ import java.util.function.BiFunction
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 
 import com.github.benmanes.caffeine.cache.{ AsyncCache, Caffeine }
 import org.apache.pekko
@@ -28,7 +29,6 @@ import pekko.http.caching.LfuCache.toJavaMappingFunction
 import pekko.http.caching.scaladsl.Cache
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.caching.CacheJavaMapping.Implicits._
-import pekko.util.FutureConverters._
 import pekko.util.FunctionConverters._
 
 @ApiMayChange

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/Cache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/Cache.scala
@@ -19,11 +19,11 @@ import java.util.concurrent.{ CompletableFuture, CompletionStage }
 import org.apache.pekko
 import pekko.annotation.{ ApiMayChange, DoNotInherit }
 import pekko.japi.function.{ Creator, Procedure }
-import pekko.util.FutureConverters._
 
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 
 /**
  * API MAY CHANGE

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
@@ -158,7 +158,7 @@ private[pekko] object OutgoingConnectionBuilderImpl {
 
     private def javaFlow(flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]])
         : JFlow[javadsl.model.HttpRequest, javadsl.model.HttpResponse, CompletionStage[javadsl.OutgoingConnection]] = {
-      import pekko.util.FutureConverters._
+      import scala.jdk.FutureConverters._
       javaFlowKeepMatVal(flow.mapMaterializedValue(f =>
         f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContext.parasitic).asJava))
     }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/JavaMapping.scala
@@ -34,10 +34,10 @@ import pekko.http.javadsl.{
 }
 import pekko.http.{ javadsl => jdsl, scaladsl => sdsl }
 import pekko.http.scaladsl.{ model => sm }
-import pekko.util.FutureConverters._
 
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 import scala.util.Try

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ClientTransport.scala
@@ -97,7 +97,7 @@ object ClientTransport {
    *               to an [[InetSocketAddress]]
    */
   def withCustomResolver(lookup: BiFunction[String, Int, CompletionStage[InetSocketAddress]]): ClientTransport = {
-    import pekko.util.FutureConverters._
+    import scala.jdk.FutureConverters._
     scaladsl.ClientTransport.withCustomResolver((host, port) => lookup.apply(host, port).asScala).asJava
   }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/Http.scala
@@ -18,6 +18,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
+import scala.jdk.FutureConverters._
 import scala.util.Try
 
 import org.apache.pekko
@@ -37,7 +38,6 @@ import pekko.stream.TLSProtocol._
 import pekko.stream.Materializer
 import pekko.stream.javadsl.{ BidiFlow, Flow }
 import pekko.stream.scaladsl.Keep
-import pekko.util.FutureConverters._
 
 object Http extends ExtensionId[Http] with ExtensionIdProvider {
   override def get(system: ActorSystem): Http = super.get(system)

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/IncomingConnection.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/IncomingConnection.scala
@@ -13,7 +13,9 @@
 
 package org.apache.pekko.http.javadsl
 
+import java.util.concurrent.CompletionStage
 import java.net.InetSocketAddress
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.japi.function.Function
@@ -21,9 +23,9 @@ import pekko.stream.Materializer
 import pekko.stream.javadsl.Flow
 import pekko.http.javadsl.model._
 import pekko.http.scaladsl.{ model => sm }
-import pekko.util.FutureConverters._
-import java.util.concurrent.CompletionStage
+
 import scala.concurrent.Future
+import scala.jdk.FutureConverters._
 
 /**
  * Represents one accepted incoming HTTP connection.

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBinding.scala
@@ -20,11 +20,11 @@ import org.apache.pekko
 import pekko.Done
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.DoNotInherit
-import pekko.util.FutureConverters._
 import pekko.util.JavaDurationConverters._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.FutureConverters._
 
 /**
  * Represents a prospective HTTP server binding.

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/ServerBuilder.scala
@@ -27,9 +27,9 @@ import pekko.http.scaladsl.{ model => sm }
 import pekko.japi.function.Function
 import pekko.stream.javadsl.{ Flow, Source }
 import pekko.stream.{ Materializer, SystemMaterializer }
-import pekko.util.FutureConverters._
 
 import scala.concurrent.ExecutionContext
+import scala.jdk.FutureConverters._
 
 /**
  * Builder API to create server bindings.

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/model/ws/Message.scala
@@ -21,9 +21,9 @@ import pekko.http.scaladsl.{ model => sm }
 import pekko.stream.Materializer
 import pekko.stream.javadsl.Source
 import pekko.util.ByteString
-import pekko.util.FutureConverters._
 
 import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 
 /**
  * Represents a WebSocket message. A message can either be a binary message or a text message.

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
@@ -44,11 +44,11 @@ import pekko.stream._
 import pekko.stream.TLSProtocol._
 import pekko.stream.scaladsl._
 import pekko.util.ByteString
-import pekko.util.FutureConverters._
 import pekko.util.ManifestInfo
 
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 import scala.util.{ Success, Try }
 import scala.util.control.NonFatal
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpEntity.scala
@@ -24,6 +24,7 @@ import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.collection.immutable
+import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
 
@@ -39,7 +40,6 @@ import pekko.http.scaladsl.util.FastFuture
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.impl.util.{ JavaMapping, StreamUtils }
 import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.util.FutureConverters._
 
 /**
  * Models the entity (aka "body" or "content") of an HTTP message.

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -34,11 +34,11 @@ import pekko.http.ccompat.{ pre213, since213 }
 import pekko.http.impl.util._
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.scaladsl.util.FastFuture._
-import pekko.util.FutureConverters._
 import headers._
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 
 /**
  * Common base class of HttpRequest and HttpResponse.

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -33,12 +33,12 @@ import pekko.stream.Materializer
 import pekko.stream.javadsl.{ Source => JSource }
 import pekko.stream.scaladsl._
 import pekko.util.ConstantFun
-import pekko.util.FutureConverters._
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import scala.collection.immutable
 import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success, Try }
 
 /**

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/ws/Message.scala
@@ -19,10 +19,10 @@ import org.apache.pekko
 import pekko.stream.{ javadsl, Materializer }
 import pekko.stream.scaladsl.Source
 import pekko.util.{ ByteString, ByteStringBuilder }
-import pekko.util.FutureConverters._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 
 //#message-model
 /**

--- a/http-core/src/test/scala/org/apache/pekko/http/javadsl/model/MultipartsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/javadsl/model/MultipartsSpec.scala
@@ -15,18 +15,18 @@ package org.apache.pekko.http.javadsl.model
 
 import java.util
 
-import com.typesafe.config.{ Config, ConfigFactory }
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.scalatest.{ BeforeAndAfterAll, Inside }
+import scala.jdk.FutureConverters._
+
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.SystemMaterializer
 import pekko.stream.javadsl.Source
 import pekko.testkit._
-import pekko.util.FutureConverters._
 
+import org.scalatest.{ BeforeAndAfterAll, Inside }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-tests/src/test/java/org/apache/pekko/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
+++ b/http-tests/src/test/java/org/apache/pekko/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
@@ -16,17 +16,19 @@
 
 package org.apache.pekko.http.javadsl.unmarshalling.sse;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.model.HttpEntity;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.http.javadsl.model.sse.ServerSentEvent;
 import org.apache.pekko.http.scaladsl.unmarshalling.sse.EventStreamUnmarshallingSpec;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
-import static org.apache.pekko.util.FutureConverters.asJava;
+
+import static scala.jdk.javaapi.FutureConverters.asJava;
 
 public class EventStreamUnmarshallingTest extends JUnitSuite {
 

--- a/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
+++ b/http/src/main/java/org/apache/pekko/http/javadsl/coding/Coder.java
@@ -21,8 +21,9 @@ import org.apache.pekko.http.scaladsl.coding.Deflate$;
 import org.apache.pekko.http.scaladsl.coding.Gzip$;
 import org.apache.pekko.http.scaladsl.coding.NoCoding$;
 import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.util.FutureConverters;
 import org.apache.pekko.util.ByteString;
+
+import scala.jdk.javaapi.FutureConverters;
 
 /** A coder is an implementation of the predefined encoders/decoders defined for HTTP. */
 public enum Coder {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
@@ -33,10 +33,10 @@ import pekko.http.scaladsl.marshalling.ToResponseMarshallable
 import pekko.http.scaladsl.model.Uri.Path
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.stream.Materializer
-import pekko.util.FutureConverters._
 
 import scala.annotation.varargs
 import scala.concurrent.ExecutionContextExecutor
+import scala.jdk.FutureConverters._
 
 class RequestContext private (val delegate: scaladsl.server.RequestContext) {
   import RequestContext._

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
@@ -99,7 +99,7 @@ private[http] object RoutingJavaMapping {
   //  val javaToScalaResponseEntity extends Inherited[javadsl.model.ResponseEntity, scaladsl.model.ResponseEntity]
 
   implicit final class ConvertCompletionStage[T](val stage: CompletionStage[T]) extends AnyVal {
-    import pekko.util.FutureConverters._
+    import scala.jdk.FutureConverters._
     def asScala = CompletionStageOps(stage).asScala
   }
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -22,22 +22,25 @@ import pekko.japi.Util
 import pekko.stream.Materializer
 import pekko.stream.javadsl.Source
 import pekko.util.ByteString
-import pekko.util.FutureConverters._
 
 import pekko.http.impl.model.JavaUri
 import pekko.http.impl.util.JavaMapping
 import pekko.http.impl.util.Util.convertIterable
-import pekko.http.javadsl.model.{ HttpEntity, HttpRequest, RequestEntity, Uri }
+import pekko.http.javadsl.model.{
+  HttpEntity,
+  HttpHeader,
+  HttpRequest,
+  HttpResponse,
+  RequestEntity,
+  ResponseEntity,
+  Uri
+}
+import pekko.http.javadsl.server
 import pekko.http.javadsl.server._
 import pekko.http.javadsl.settings.{ ParserSettings, RoutingSettings }
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server.{ Directives => D }
-
-import pekko.http.javadsl.model.HttpResponse
-import pekko.http.javadsl.model.ResponseEntity
-import pekko.http.javadsl.model.HttpHeader
 import pekko.http.scaladsl.util.FastFuture._
-import pekko.http.javadsl.server
 
 import java.lang.{ Iterable => JIterable }
 import java.util.function.Supplier
@@ -47,6 +50,7 @@ import java.util.function.Predicate
 
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.FutureConverters._
 
 abstract class BasicDirectives {
   import pekko.http.impl.util.JavaMapping.Implicits._

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
@@ -24,9 +24,9 @@ import pekko.http.javadsl.model.RequestEntity
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.directives.{ CompleteOrRecoverWithMagnet, FutureDirectives => D }
 import pekko.pattern.CircuitBreaker
-import pekko.util.FutureConverters._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.FutureConverters._
 import scala.util.Try
 
 abstract class FutureDirectives extends FormFieldDirectives {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteAdapter.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteAdapter.scala
@@ -39,7 +39,7 @@ final class RouteAdapter(val delegate: pekko.http.scaladsl.server.Route) extends
     scalaFlow(system, materializer).asJava
 
   override def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = {
-    import pekko.util.FutureConverters._
+    import scala.jdk.FutureConverters._
     val scalaFunction = scaladsl.server.Route.toFunction(delegate)(system)
     request => (scalaFunction(request.asScala): Future[HttpResponse]).asJava
   }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
@@ -24,9 +24,9 @@ import pekko.http.javadsl.model.headers.HttpCredentials
 import pekko.http.javadsl.server.{ RequestContext, Route }
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server.{ Directives => D }
-import pekko.util.FutureConverters._
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
 
 object SecurityDirectives {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -31,11 +31,11 @@ import pekko.http.scaladsl.unmarshalling.Unmarshaller.EnhancedFromEntityUnmarsha
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.util.ByteString
-import pekko.util.FutureConverters._
 
 import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 
 object Unmarshaller extends pekko.http.javadsl.unmarshalling.Unmarshallers {
   implicit def fromScala[A, B](scalaUnmarshaller: unmarshalling.Unmarshaller[A, B]): Unmarshaller[A, B] =


### PR DESCRIPTION
now that we no longer support Scala 2.12 in main branch