### PR TITLE
Resort imports

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,7 +3,6 @@ rules = [
   RemoveUnused
   SortImports
   ExplicitResultTypes
-  "github:ohze/scalafix-rules/FinalObject"
   fix.scala213.DottyMigrate
 //  fix.scala213.NullaryOverride
 ]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,55 @@
+// .scalafix.conf
+rules = [
+  RemoveUnused
+  SortImports
+  ExplicitResultTypes
+  "github:ohze/scalafix-rules/FinalObject"
+  fix.scala213.DottyMigrate
+//  fix.scala213.NullaryOverride
+]
+//NullaryOverride.mode = Rewrite
+ExplicitResultTypes {
+  memberVisibility = [] # only rewrite implicit members
+  skipSimpleDefinitions = []
+}
+ExplicitImplicitTypes.symbolReplacements {
+  "scala/concurrent/ExecutionContextExecutor#" = "scala/concurrent/ExecutionContext#"
+}
+RemoveUnused.imports = true
+RemoveUnused.privates = false
+RemoveUnused.locals = false
+
+//ignored files
+ignored-files = [
+  "TypedBenchmarkActors.scala",
+  "FlowPrependSpec.scala",
+  "FlowZipSpec.scala",
+  "FlowZipWithSpec.scala",
+  "FlowZipWithIndexSpec.scala",
+  "SourceSpec.scala",
+  "StatsSampleSpec.scala",
+  "ActorFlowSpec.scala",
+  "FSMTimingSpec.scala"
+]
+
+//ignored packages
+ignored-packages = [
+  "docs",
+  "doc",
+  "jdoc"
+]
+
+//sort imports, see https://github.com/NeQuissimus/sort-imports
+SortImports.asciiSort = false
+SortImports.blocks = [
+  "re:javax?\\.",
+  "scala.",
+  "*",
+  "com.sun."
+  "re:^(org\\.apache\\.pekko|pekko\\.)\\w*"
+  "org.reactivestreams."
+  "io.netty."
+  "org.scalatest."
+  "org.slf4j."
+  "com.typesafe."
+]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,7 +3,6 @@ rules = [
   RemoveUnused
   SortImports
   ExplicitResultTypes
-  fix.scala213.DottyMigrate
 //  fix.scala213.NullaryOverride
 ]
 //NullaryOverride.mode = Rewrite

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -20,16 +20,10 @@ RemoveUnused.privates = false
 RemoveUnused.locals = false
 
 //ignored files
+// usually due them being used in our documentation - docs module is ignored anyway
+// but some tests in other modules are also used used in the paradox build
 ignored-files = [
-  "TypedBenchmarkActors.scala",
-  "FlowPrependSpec.scala",
-  "FlowZipSpec.scala",
-  "FlowZipWithSpec.scala",
-  "FlowZipWithIndexSpec.scala",
-  "SourceSpec.scala",
-  "StatsSampleSpec.scala",
-  "ActorFlowSpec.scala",
-  "FSMTimingSpec.scala"
+  "CustomMediaTypesSpec.scala"
 ]
 
 //ignored packages

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; +headerCheckAll; javafmtCheckAll")
 addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+addCommandAlias(name = "sortImports", value = ";scalafixEnable; scalafixAll SortImports; scalafmtAll")
 
 inThisBuild(Def.settings(
   apiURL := {
@@ -364,7 +365,7 @@ lazy val httpScalafixTests =
 
 lazy val docs = project("docs")
   .enablePlugins(ParadoxPlugin, PekkoParadoxPlugin, NoPublish)
-  .disablePlugins(MimaPlugin)
+  .disablePlugins(MimaPlugin, ScalafixPlugin)
   .addPekkoModuleDependency("pekko-stream", "provided", PekkoCoreDependency.default)
   .addPekkoModuleDependency("pekko-actor-typed", "provided", PekkoCoreDependency.default)
   .addPekkoModuleDependency("pekko-multi-node-testkit", "provided", PekkoCoreDependency.default)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/cors/CorsBenchmark.scala
@@ -19,21 +19,23 @@ package org.apache.pekko.http.cors
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.pekko
-import pekko.actor.ActorSystem
-import pekko.http.scaladsl.Http
-import pekko.http.scaladsl.Http.ServerBinding
-import pekko.http.scaladsl.model.headers.{ `Access-Control-Request-Method`, Origin }
-import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest }
-import pekko.http.scaladsl.server.Directives
-import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.http.cors.scaladsl.CorsDirectives
-import pekko.http.cors.scaladsl.settings.CorsSettings
-import com.typesafe.config.ConfigFactory
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.duration._
+
 import org.openjdk.jmh.annotations._
 
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext }
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.cors.scaladsl.CorsDirectives
+import pekko.http.cors.scaladsl.settings.CorsSettings
+import pekko.http.scaladsl.Http
+import pekko.http.scaladsl.Http.ServerBinding
+import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest }
+import pekko.http.scaladsl.model.headers.{ `Access-Control-Request-Method`, Origin }
+import pekko.http.scaladsl.server.Directives
+import pekko.http.scaladsl.unmarshalling.Unmarshal
+
+import com.typesafe.config.ConfigFactory
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -16,20 +16,22 @@ package org.apache.pekko.http.impl.engine
 import java.net.InetSocketAddress
 import java.util.concurrent.CountDownLatch
 
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+
+import org.openjdk.jmh.annotations._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.CommonBenchmark
 import pekko.http.impl.util.enhanceString_
+import pekko.http.scaladsl.{ ClientTransport, Http }
 import pekko.http.scaladsl.model.HttpRequest
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
-import pekko.http.scaladsl.{ ClientTransport, Http }
 import pekko.stream.scaladsl.Flow
 import pekko.util.ByteString
-import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations._
 
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
+import com.typesafe.config.ConfigFactory
 
 /**
  * A benchmark that tries to stress the pool and the client infrastructure (but nothing else)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HeaderParserBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HeaderParserBenchmark.scala
@@ -15,17 +15,19 @@ package org.apache.pekko.http.impl.engine
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import org.openjdk.jmh.annotations._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.impl.engine.parsing.HttpHeaderParser
 import pekko.http.impl.settings.ParserSettingsImpl
 import pekko.http.scaladsl.model.MediaType
 import pekko.util.ByteString
-import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations._
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import com.typesafe.config.ConfigFactory
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HttpEntityBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/HttpEntityBenchmark.scala
@@ -15,16 +15,18 @@ package org.apache.pekko.http.impl.engine
 
 import java.util.concurrent.CountDownLatch
 
+import scala.concurrent.ExecutionContext
+
+import org.openjdk.jmh.annotations.{ Benchmark, Param, Setup, TearDown }
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.CommonBenchmark
 import pekko.http.scaladsl.model.{ ContentTypes, HttpEntity }
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
-import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations.{ Benchmark, Param, Setup, TearDown }
 
-import scala.concurrent.ExecutionContext
+import com.typesafe.config.ConfigFactory
 
 class HttpEntityBenchmark extends CommonBenchmark {
   @Param(Array("strict", "default"))

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/MessageToFrameRendererBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/MessageToFrameRendererBenchmark.scala
@@ -17,15 +17,11 @@
 
 package org.apache.pekko.http.impl.engine
 
-import com.typesafe.config.ConfigFactory
+import java.util.concurrent.TimeUnit
 
-import org.apache.pekko
-import pekko.{ BenchTestSourceSameElement, NotUsed }
-import pekko.actor.ActorSystem
-import pekko.http.impl.engine.ws.FrameEvent
-import pekko.http.impl.engine.ws.Protocol.Opcode
-import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import pekko.util.ByteString
+import scala.concurrent.Await
+import scala.concurrent.duration.{ Duration, DurationInt }
+
 import org.openjdk.jmh.annotations.{
   Benchmark,
   BenchmarkMode,
@@ -37,9 +33,15 @@ import org.openjdk.jmh.annotations.{
   TearDown
 }
 
-import java.util.concurrent.TimeUnit
-import scala.concurrent.Await
-import scala.concurrent.duration.{ Duration, DurationInt }
+import org.apache.pekko
+import pekko.{ BenchTestSourceSameElement, NotUsed }
+import pekko.actor.ActorSystem
+import pekko.http.impl.engine.ws.FrameEvent
+import pekko.http.impl.engine.ws.Protocol.Opcode
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.util.ByteString
+
+import com.typesafe.config.ConfigFactory
 
 object MessageToFrameRendererBenchmark {
   final val OperationsPerInvocation = 100000

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ServerProcessingBenchmark.scala
@@ -14,6 +14,9 @@
 package org.apache.pekko.http.impl.engine
 
 import java.util.concurrent.CountDownLatch
+
+import org.openjdk.jmh.annotations._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.NoLogging
@@ -27,8 +30,8 @@ import pekko.stream.scaladsl.Flow
 import pekko.stream.scaladsl.Source
 import pekko.stream.scaladsl.TLSPlacebo
 import pekko.util.ByteString
+
 import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations._
 
 class ServerProcessingBenchmark extends CommonBenchmark {
   val request = ByteString("GET / HTTP/1.1\r\nHost: localhost\r\nUser-Agent: test\r\n\r\n")

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/StreamServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/StreamServerProcessingBenchmark.scala
@@ -15,6 +15,9 @@ package org.apache.pekko.http.impl.engine
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.NoLogging
@@ -32,8 +35,8 @@ import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 import pekko.stream.scaladsl.TLSPlacebo
 import pekko.util.ByteString
+
 import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations._
 
 @Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 class StreamServerProcessingBenchmark extends CommonBenchmark {

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -13,6 +13,13 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration._
+
+import org.openjdk.jmh.annotations._
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ActorSystem
@@ -24,12 +31,8 @@ import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import pekko.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import pekko.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, Source }
 import pekko.util.ByteString
-import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations._
 
-import java.util.concurrent.{ CountDownLatch, TimeUnit }
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import com.typesafe.config.ConfigFactory
 
 /**
  * Test converting a HttpRequest to bytes at the client and back to a request at the server, and vice-versa

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2RequestResponseBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2RequestResponseBenchmark.scala
@@ -13,10 +13,11 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import org.openjdk.jmh.annotations.Param
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.FrameEvent.{ DataFrame, HeadersFrame }
 import pekko.http.impl.engine.http2.framing.FrameRenderer
-import pekko.http.scaladsl.model.HttpEntity.{ Chunk, LastChunk }
 import pekko.http.scaladsl.model.{
   AttributeKeys,
   ContentTypes,
@@ -26,11 +27,12 @@ import pekko.http.scaladsl.model.{
   HttpResponse,
   Trailer
 }
+import pekko.http.scaladsl.model.HttpEntity.{ Chunk, LastChunk }
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
+
 import com.typesafe.config.ConfigFactory
-import org.openjdk.jmh.annotations.Param
 
 trait H2RequestResponseBenchmark extends HPackEncodingSupport {
   @Param(Array("1"))

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -13,6 +13,13 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration._
+
+import org.openjdk.jmh.annotations._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.CommonBenchmark
@@ -22,11 +29,6 @@ import pekko.http.scaladsl.settings.ServerSettings
 import pekko.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import pekko.util.ByteString
-import org.openjdk.jmh.annotations._
-
-import java.util.concurrent.{ CountDownLatch, TimeUnit }
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext, Future }
 
 class H2ServerProcessingBenchmark extends CommonBenchmark with H2RequestResponseBenchmark {
 

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ws/MaskingBench.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/engine/ws/MaskingBench.scala
@@ -16,8 +16,8 @@ package org.apache.pekko.http.impl.engine.ws
 import org.openjdk.jmh.annotations.Benchmark
 
 import org.apache.pekko
-import pekko.util.ByteString
 import pekko.http.CommonBenchmark
+import pekko.util.ByteString
 
 class MaskingBench extends CommonBenchmark {
   val data = ByteString(new Array[Byte](10000))

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/model/parser/UriParserBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/impl/model/parser/UriParserBenchmark.scala
@@ -15,11 +15,12 @@ package org.apache.pekko.http.impl.model.parser
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.pekko
-import pekko.http.scaladsl.model.Uri
-import org.parboiled2.UTF8
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
+import org.parboiled2.UTF8
+
+import org.apache.pekko
+import pekko.http.scaladsl.model.Uri
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
@@ -16,16 +16,17 @@ package org.apache.pekko.http.scaladsl.unmarshalling.sse
 import java.nio.file.{ Files, Path }
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.ActorSystem
 import pekko.stream.scaladsl.{ FileIO, Keep, RunnableGraph, Sink, Source }
 import pekko.util.ByteString
-import org.openjdk.jmh.annotations._
-import org.openjdk.jmh.infra.Blackhole
-
-import scala.concurrent.{ Await, Future }
-import scala.concurrent.duration._
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/LfuCache.scala
@@ -16,20 +16,21 @@ package org.apache.pekko.http.caching
 import java.util.concurrent.{ CompletableFuture, Executor, TimeUnit }
 import java.util.function.BiFunction
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 import scala.jdk.FunctionConverters._
 import scala.jdk.FutureConverters._
 
 import com.github.benmanes.caffeine.cache.{ AsyncCache, Caffeine }
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.{ ApiMayChange, InternalApi }
+import pekko.http.caching.CacheJavaMapping.Implicits._
 import pekko.http.caching.LfuCache.toJavaMappingFunction
 import pekko.http.caching.scaladsl.Cache
 import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.http.caching.CacheJavaMapping.Implicits._
 
 @ApiMayChange
 object LfuCache {

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/CachingSettingsImpl.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/CachingSettingsImpl.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.caching.scaladsl.{ CachingSettings, LfuCacheSettings }
 import pekko.http.impl.util.SettingsCompanionImpl
+
 import com.typesafe.config.Config
 
 /** INTERNAL API */

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/LfuCachingSettingsImpl.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/impl/settings/LfuCachingSettingsImpl.scala
@@ -13,14 +13,15 @@
 
 package org.apache.pekko.http.caching.impl.settings
 
+import scala.concurrent.duration.Duration
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.caching.scaladsl.LfuCacheSettings
-import pekko.http.impl.util.SettingsCompanionImpl
 import pekko.http.impl.util._
-import com.typesafe.config.Config
+import pekko.http.impl.util.SettingsCompanionImpl
 
-import scala.concurrent.duration.Duration
+import com.typesafe.config.Config
 
 /** INTERNAL API */
 @InternalApi

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/javadsl/CachingSettings.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/javadsl/CachingSettings.scala
@@ -18,6 +18,7 @@ import pekko.actor.ActorSystem
 import pekko.annotation.DoNotInherit
 import pekko.http.caching.impl.settings.CachingSettingsImpl
 import pekko.http.javadsl.settings.SettingsCompanion
+
 import com.typesafe.config.Config
 
 /**
@@ -29,8 +30,8 @@ abstract class CachingSettings private[http] () { self: CachingSettingsImpl =>
 
   // overloads for idiomatic Scala use
   def withLfuCacheSettings(newSettings: LfuCacheSettings): CachingSettings = {
-    import pekko.http.impl.util.JavaMapping.Implicits._
     import pekko.http.caching.CacheJavaMapping.Implicits._
+    import pekko.http.impl.util.JavaMapping.Implicits._
 
     self.copy(lfuCacheSettings = newSettings.asScala)
   }

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/javadsl/LfuCacheSettings.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/javadsl/LfuCacheSettings.scala
@@ -13,14 +13,15 @@
 
 package org.apache.pekko.http.caching.javadsl
 
+import scala.concurrent.duration.Duration
+import scala.jdk.DurationConverters._
+
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
 import pekko.http.caching.impl.settings.LfuCachingSettingsImpl
 import pekko.http.javadsl.settings.SettingsCompanion
-import com.typesafe.config.Config
 
-import scala.concurrent.duration.Duration
-import scala.jdk.DurationConverters._
+import com.typesafe.config.Config
 
 /**
  * Public API but not intended for subclassing

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/Cache.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/Cache.scala
@@ -16,14 +16,14 @@ package org.apache.pekko.http.caching.scaladsl
 import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
-import org.apache.pekko
-import pekko.annotation.{ ApiMayChange, DoNotInherit }
-import pekko.japi.function.{ Creator, Procedure }
-
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
+
+import org.apache.pekko
+import pekko.annotation.{ ApiMayChange, DoNotInherit }
+import pekko.japi.function.{ Creator, Procedure }
 
 /**
  * API MAY CHANGE

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/CachingSettings.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/CachingSettings.scala
@@ -18,6 +18,7 @@ import pekko.annotation.DoNotInherit
 import pekko.http.caching.impl.settings.CachingSettingsImpl
 import pekko.http.caching.javadsl
 import pekko.http.scaladsl.settings.SettingsCompanion
+
 import com.typesafe.config.Config
 
 /**

--- a/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/LfuCacheSettings.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/caching/scaladsl/LfuCacheSettings.scala
@@ -13,15 +13,16 @@
 
 package org.apache.pekko.http.caching.scaladsl
 
+import scala.concurrent.duration.Duration
+
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
 import pekko.http.caching.impl.settings.LfuCachingSettingsImpl
 import pekko.http.caching.javadsl
 import pekko.http.impl.util.JavaDurationConverter
 import pekko.http.scaladsl.settings.SettingsCompanion
-import com.typesafe.config.Config
 
-import scala.concurrent.duration.Duration
+import com.typesafe.config.Config
 
 /**
  * Public API but not intended for subclassing

--- a/http-caching/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CachingDirectives.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/javadsl/server/directives/CachingDirectives.scala
@@ -17,8 +17,8 @@ import java.util.function.Supplier
 
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
-import pekko.http.caching.javadsl.{ Cache, CachingSettings }
 import pekko.http.caching.{ CacheJavaMapping, LfuCache }
+import pekko.http.caching.javadsl.{ Cache, CachingSettings }
 import pekko.http.impl.util.JavaMapping
 import pekko.http.javadsl.server.{ RequestContext, Route, RouteResult }
 

--- a/http-caching/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CachingDirectives.scala
+++ b/http-caching/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CachingDirectives.scala
@@ -13,17 +13,17 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
+import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.ApiMayChange
-import pekko.http.caching.scaladsl.{ Cache, CachingSettings }
 import pekko.http.caching.LfuCache
-import pekko.http.scaladsl.server.Directive0
-import pekko.http.scaladsl.server._
+import pekko.http.caching.scaladsl.{ Cache, CachingSettings }
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.model.headers.CacheDirectives._
-
-import scala.concurrent.Future
+import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.Directive0
 
 @ApiMayChange
 trait CachingDirectives {

--- a/http-caching/src/test/scala/org/apache/pekko/http/caching/ExpiringLfuCacheSpec.scala
+++ b/http-caching/src/test/scala/org/apache/pekko/http/caching/ExpiringLfuCacheSpec.scala
@@ -16,14 +16,15 @@ package org.apache.pekko.http.caching
 import java.util.Random
 import java.util.concurrent.CountDownLatch
 
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.caching.scaladsl.CachingSettings
 import pekko.testkit.TestKit
-import org.scalatest.BeforeAndAfterAll
 
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future, Promise }
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-caching/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CachingDirectivesSpec.scala
+++ b/http-caching/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CachingDirectivesSpec.scala
@@ -13,22 +13,23 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.caching.scaladsl.{ CachingSettings, LfuCacheSettings }
 import pekko.http.impl.util._
-import pekko.http.scaladsl.model.HttpMethods.GET
-import pekko.http.scaladsl.model.headers.CacheDirectives._
-import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.model.{ HttpResponse, Uri }
-import pekko.http.scaladsl.server.Directives._
+import pekko.http.scaladsl.model.HttpMethods.GET
+import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.model.headers.CacheDirectives._
 import pekko.http.scaladsl.server.{ ExceptionHandler, RequestContext, RouteResult }
+import pekko.http.scaladsl.server.Directives._
 import pekko.http.scaladsl.testkit.ScalatestRouteTest
 import pekko.testkit._
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class CachingDirectivesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest with CachingDirectives {
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
@@ -26,7 +26,7 @@ import pekko.util.ByteString
 import pekko.http.scaladsl.model._
 import pekko.http.impl.util._
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
-import headers._
+import pekko.http.scaladsl.model.headers._
 
 import scala.collection.mutable.ListBuffer
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
@@ -25,7 +25,7 @@ import pekko.util.ByteString
 import pekko.http.impl.model.parser.CharacterClasses
 import pekko.http.scaladsl.settings.ParserSettings
 import pekko.http.scaladsl.model.{ ParsingException => _, _ }
-import headers._
+import pekko.http.scaladsl.model.headers._
 import HttpProtocols._
 import ParserOutput._
 import pekko.annotation.InternalApi

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpRequestParser.scala
@@ -17,6 +17,7 @@ import java.lang.{ StringBuilder => JStringBuilder }
 import javax.net.ssl.SSLSession
 
 import scala.annotation.{ switch, tailrec }
+
 import org.apache.pekko
 import pekko.http.scaladsl.settings.{ ParserSettings, WebSocketSettings }
 import pekko.util.ByteString
@@ -24,16 +25,16 @@ import pekko.util.OptionVal
 import pekko.http.impl.engine.ws.Handshake
 import pekko.http.impl.model.parser.{ CharacterClasses, UriParser }
 import pekko.http.scaladsl.model.{ ParsingException => _, _ }
-import headers._
-import StatusCodes._
+import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.model.StatusCodes._
 import ParserOutput._
 import pekko.annotation.InternalApi
 import pekko.http.impl.engine.server.HttpAttributes
 import pekko.http.impl.util.ByteStringParserInput
-import org.parboiled2.ParserInput
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import pekko.stream.TLSProtocol.SessionBytes
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import org.parboiled2.ParserInput
 
 /**
  * INTERNAL API

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -19,13 +19,13 @@ import org.parboiled2.util.Base64
 import scala.collection.immutable
 import pekko.event.LoggingAdapter
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpEntity._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.impl.engine.rendering.RenderSupport._
 import pekko.http.impl.util._
 import pekko.stream.scaladsl.Source
 import pekko.stream.stage._
 import pekko.util.ByteString
-import HttpEntity._
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import java.util.concurrent.ThreadLocalRandom
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -28,7 +28,7 @@ import pekko.http.scaladsl.model._
 import pekko.http.impl.util._
 import RenderSupport._
 import pekko.annotation.InternalApi
-import headers._
+import pekko.http.scaladsl.model.headers._
 
 /**
  * INTERNAL API

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -13,28 +13,25 @@
 
 package org.apache.pekko.http.impl.engine.rendering
 
+import scala.annotation.tailrec
+import scala.collection.immutable
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.NotUsed
-import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
-
-import scala.collection.immutable
-import scala.annotation.tailrec
-import pekko.event.LoggingAdapter
-import pekko.util.ByteString
-import pekko.stream.scaladsl.{ Flow, Source }
-import pekko.stream.stage._
-import pekko.http.scaladsl.model._
-import pekko.http.impl.util._
-import pekko.util.OptionVal
-import RenderSupport._
-import HttpProtocols._
 import pekko.annotation.InternalApi
-import ResponseRenderingContext.CloseRequested
+import pekko.event.LoggingAdapter
 import pekko.http.impl.engine.server.UpgradeToOtherProtocolResponseHeader
-import pekko.stream.scaladsl.Sink
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpProtocols._
 import pekko.http.scaladsl.model.headers._
-
-import scala.util.control.NonFatal
+import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
+import pekko.stream.stage._
+import pekko.util.{ ByteString, OptionVal }
+import RenderSupport._
+import ResponseRenderingContext.CloseRequested
 
 /**
  * INTERNAL API

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -32,7 +32,7 @@ import pekko.annotation.InternalApi
 import ResponseRenderingContext.CloseRequested
 import pekko.http.impl.engine.server.UpgradeToOtherProtocolResponseHeader
 import pekko.stream.scaladsl.Sink
-import headers._
+import pekko.http.scaladsl.model.headers._
 
 import scala.util.control.NonFatal
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/CacheControlHeader.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/CacheControlHeader.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.http.impl.model.parser
 
 import org.apache.pekko
 import pekko.http.scaladsl.model.headers._
-import CacheDirectives._
+import pekko.http.scaladsl.model.headers.CacheDirectives._
 
 private[parser] trait CacheControlHeader { this: HeaderParser =>
 

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -33,7 +33,7 @@ import pekko.util.{ ByteString, HashCode, OptionVal }
 import pekko.http.impl.util._
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.scaladsl.util.FastFuture._
-import headers._
+import pekko.http.scaladsl.model.headers._
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Multipart.scala
@@ -26,8 +26,8 @@ import pekko.http.impl.util.{ DefaultNoLogging, Util }
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.scaladsl.util.FastFuture
+import pekko.http.scaladsl.util.FastFuture._
 import pekko.http.scaladsl.model.headers._
-import FastFuture._
 import pekko.stream.Materializer
 import pekko.stream.javadsl.{ Source => JSource }
 import pekko.stream.scaladsl._

--- a/http-core/src/test/scala/io/pekko/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/http-core/src/test/scala/io/pekko/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -24,7 +24,7 @@ import pekko.actor.ActorSystem
 import pekko.http.scaladsl.model._
 import pekko.stream.scaladsl._
 import pekko.testkit._
-import headers._
+import pekko.http.scaladsl.model.headers._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -13,32 +13,33 @@
 
 package org.apache.pekko.http.impl.engine.parsing
 
-import org.apache.pekko
-import pekko.NotUsed
-import pekko.http.scaladsl.settings.ParserSettings
-import pekko.http.scaladsl.util.FastFuture
-import pekko.stream.TLSProtocol._
-
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import org.scalatest.matchers.Matcher
+
+import org.apache.pekko
+import pekko.NotUsed
+import pekko.stream.TLSProtocol._
 import pekko.util.ByteString
 import pekko.stream.scaladsl._
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
-import pekko.http.scaladsl.util.FastFuture._
 import pekko.http.impl.util._
+import pekko.http.impl.engine.parsing.ParserOutput._
+import pekko.http.scaladsl.settings.ParserSettings
+import pekko.http.scaladsl.util.FastFuture
+import pekko.http.scaladsl.util.FastFuture._
 import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.model.headers._
-import MediaTypes._
-import HttpProtocols._
+import pekko.http.scaladsl.model.HttpEntity._
 import pekko.http.scaladsl.model.HttpMethods._
-import pekko.http.scaladsl.model.StatusCodes._
-import HttpEntity._
-import ParserOutput._
+import pekko.http.scaladsl.model.HttpProtocols._
 import pekko.http.scaladsl.model.MediaType.WithOpenCharset
+import pekko.http.scaladsl.model.MediaTypes._
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.settings.ParserSettings.ConflictingContentTypeHeaderProcessingMode
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.testkit._
+
+import org.scalatest.matchers.Matcher
 
 abstract class ResponseParserSpec(mode: String, newLine: String) extends PekkoSpecWithMaterializer(
       """

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -30,8 +30,8 @@ import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
 import MediaTypes._
-import HttpMethods._
 import HttpProtocols._
+import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
 import HttpEntity._
 import ParserOutput._

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -28,11 +28,11 @@ import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
-import headers._
+import pekko.http.scaladsl.model.headers._
 import MediaTypes._
 import HttpMethods._
 import HttpProtocols._
-import StatusCodes._
+import pekko.http.scaladsl.model.StatusCodes._
 import HttpEntity._
 import ParserOutput._
 import pekko.http.scaladsl.model.MediaType.WithOpenCharset

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -25,11 +25,11 @@ import pekko.actor.ActorSystem
 import pekko.event.NoLogging
 import pekko.util.ByteString
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpEntity._
+import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.impl.util._
 import pekko.stream.scaladsl._
-import HttpEntity._
-import HttpMethods._
 import pekko.testkit._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -23,11 +23,11 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.NoLogging
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpEntity._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.impl.util._
 import pekko.util.ByteString
 import pekko.stream.scaladsl._
-import HttpEntity._
 import pekko.http.impl.engine.rendering.ResponseRenderingContext.CloseRequested
 import pekko.http.impl.util.Rendering.CrLf
 import pekko.testkit._

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
@@ -25,11 +25,13 @@ import pekko.http.impl.util._
 import pekko.http.scaladsl.model.{ HttpHeader, _ }
 import pekko.http.scaladsl.model.MediaRanges._
 import pekko.http.scaladsl.model.MediaType.WithOpenCharset
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.model.HttpCharsets._
-import pekko.http.scaladsl.model.HttpEncodings._
 import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.headers.{ Trailer => `Trailer`, _ }
 import pekko.http.scaladsl.model.headers.CacheDirectives._
+import pekko.http.scaladsl.model.headers.CacheDirectives._
+import pekko.http.scaladsl.model.headers.HttpEncodings._
 
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/model/parser/HttpHeaderSpec.scala
@@ -13,23 +13,24 @@
 
 package org.apache.pekko.http.impl.model.parser
 
+import java.net.InetAddress
+
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
 import pekko.http.scaladsl.settings.ParserSettings.CookieParsingMode
 import pekko.http.impl.model.parser.HeaderParser.Settings
 import org.scalatest.matchers.{ MatchResult, Matcher }
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model.{ HttpHeader, _ }
-import headers.{ Trailer => `Trailer`, _ }
-import CacheDirectives._
-import MediaTypes._
-import MediaRanges._
-import HttpCharsets._
-import HttpEncodings._
-import HttpMethods._
-
-import java.net.InetAddress
-import scala.collection.immutable.Seq
+import pekko.http.scaladsl.model.MediaRanges._
 import pekko.http.scaladsl.model.MediaType.WithOpenCharset
+import pekko.http.scaladsl.model.HttpCharsets._
+import pekko.http.scaladsl.model.HttpEncodings._
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.model.headers.{ Trailer => `Trailer`, _ }
+import pekko.http.scaladsl.model.headers.CacheDirectives._
+
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/JavaDurationConverterSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/JavaDurationConverterSpec.scala
@@ -19,7 +19,6 @@ package org.apache.pekko.http.impl.util
 
 import java.time.temporal.ChronoUnit
 
-import org.apache.pekko
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TestServer.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/TestServer.scala
@@ -21,13 +21,12 @@ import pekko.NotUsed
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.AttributeKeys.webSocketUpgrade
+import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.ws._
 import pekko.stream._
 import pekko.stream.scaladsl.{ Flow, Source }
 
 import com.typesafe.config.{ Config, ConfigFactory }
-
-import HttpMethods._
 
 import scala.io.StdIn
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/HttpMessageSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/HttpMessageSpec.scala
@@ -17,7 +17,7 @@ import java.net.InetAddress
 
 import org.apache.pekko
 import pekko.util.ByteString
-import headers._
+import pekko.http.scaladsl.model.headers._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import pekko.http.javadsl.{ model => jm }

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/SerializabilitySpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/SerializabilitySpec.scala
@@ -14,10 +14,14 @@
 package org.apache.pekko.http.scaladsl.model
 
 import java.io._
-import pekko.http.scaladsl.model.headers._
-import org.scalatest.matchers.{ MatchResult, Matcher }
+
 import scala.util.Try
-import org.apache.pekko.util.ByteString
+
+import org.apache.pekko
+import pekko.util.ByteString
+import pekko.http.scaladsl.model.headers._
+
+import org.scalatest.matchers.{ MatchResult, Matcher }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/SerializabilitySpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/SerializabilitySpec.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.http.scaladsl.model
 
 import java.io._
-import headers._
+import pekko.http.scaladsl.model.headers._
 import org.scalatest.matchers.{ MatchResult, Matcher }
 import scala.util.Try
 import org.apache.pekko.util.ByteString

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/CorsDirectives.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/CorsDirectives.scala
@@ -20,12 +20,12 @@ package org.apache.pekko.http.cors.javadsl
 import java.util.function.Supplier
 
 import org.apache.pekko
-import pekko.http.javadsl.server.{ RejectionHandler, Route }
-import pekko.http.javadsl.server.directives.RouteAdapter
 import pekko.http.cors.CorsJavaMapping.Implicits._
 import pekko.http.cors.javadsl.settings.CorsSettings
 import pekko.http.cors.scaladsl
 import pekko.http.impl.util.JavaMapping
+import pekko.http.javadsl.server.{ RejectionHandler, Route }
+import pekko.http.javadsl.server.directives.RouteAdapter
 
 object CorsDirectives {
 

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/settings/CorsSettings.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/javadsl/settings/CorsSettings.scala
@@ -18,13 +18,15 @@
 package org.apache.pekko.http.cors.javadsl.settings
 
 import java.util.OptionalLong
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.DoNotInherit
-import pekko.http.javadsl.model.HttpMethod
 import pekko.http.cors.javadsl.model.{ HttpHeaderRange, HttpOriginMatcher }
 import pekko.http.cors.scaladsl
 import pekko.http.cors.scaladsl.settings.CorsSettingsImpl
+import pekko.http.javadsl.model.HttpMethod
+
 import com.typesafe.config.Config
 
 /**

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsDirectives.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsDirectives.scala
@@ -17,17 +17,17 @@
 
 package org.apache.pekko.http.cors.scaladsl
 
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
-import pekko.http.scaladsl.model.HttpMethods._
-import pekko.http.scaladsl.model.headers._
-import pekko.http.scaladsl.model.{ HttpMethod, HttpResponse, StatusCodes }
-import pekko.http.scaladsl.server._
-import pekko.http.scaladsl.server.directives._
 import pekko.http.cors.javadsl
 import pekko.http.cors.scaladsl.model.HttpOriginMatcher
 import pekko.http.cors.scaladsl.settings.CorsSettings
-
-import scala.collection.immutable.Seq
+import pekko.http.scaladsl.model.{ HttpMethod, HttpResponse, StatusCodes }
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.directives._
 
 /**
  * Provides directives that implement the CORS mechanism, enabling cross origin requests.

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsRejection.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsRejection.scala
@@ -17,16 +17,17 @@
 
 package org.apache.pekko.http.cors.scaladsl
 
+import java.util
+
+import scala.collection.immutable.Seq
+import scala.jdk.CollectionConverters._
+
 import org.apache.pekko
+import pekko.http.cors.javadsl
 import pekko.http.javadsl.model.headers
 import pekko.http.scaladsl.model.HttpMethod
 import pekko.http.scaladsl.model.headers.HttpOrigin
 import pekko.http.scaladsl.server.Rejection
-import pekko.http.cors.javadsl
-
-import java.util
-import scala.collection.immutable.Seq
-import scala.jdk.CollectionConverters._
 
 /**
  * Rejection created by the CORS directives. Signal the CORS request was rejected. The reason of the rejection is

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpHeaderRange.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpHeaderRange.scala
@@ -17,11 +17,11 @@
 
 package org.apache.pekko.http.cors.scaladsl.model
 
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
 import pekko.http.cors.javadsl
 import pekko.util.Helpers
-
-import scala.collection.immutable.Seq
 
 abstract class HttpHeaderRange extends javadsl.model.HttpHeaderRange
 

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcher.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcher.scala
@@ -17,12 +17,12 @@
 
 package org.apache.pekko.http.cors.scaladsl.model
 
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
+import pekko.http.cors.javadsl
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.scaladsl.model.headers.HttpOrigin
-import pekko.http.cors.javadsl
-
-import scala.collection.immutable.Seq
 
 /**
  * HttpOrigin matcher.

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettings.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettings.scala
@@ -20,23 +20,24 @@ package org.apache.pekko.http.cors.scaladsl.settings
 import java.util.OptionalLong
 import java.util.concurrent.TimeUnit
 
+import scala.collection.immutable.Seq
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+import scala.util.Try
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.DoNotInherit
 import pekko.http.cors.javadsl
-import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
 import pekko.http.cors.javadsl.{ model => jmcorsmodel }
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
 import pekko.http.impl.util.SettingsCompanionImpl
 import pekko.http.javadsl.{ model => jmmodel }
-import pekko.http.scaladsl.model.headers.HttpOrigin
 import pekko.http.scaladsl.model.{ HttpHeader, HttpMethod, HttpMethods }
-import com.typesafe.config.ConfigException.{ Missing, WrongType }
-import com.typesafe.config.Config
+import pekko.http.scaladsl.model.headers.HttpOrigin
 
-import scala.jdk.CollectionConverters._
-import scala.collection.immutable.Seq
-import scala.jdk.OptionConverters._
-import scala.util.Try
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigException.{ Missing, WrongType }
 
 /**
  * Settings used by the CORS directives.

--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsImpl.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsImpl.scala
@@ -17,12 +17,12 @@
 
 package org.apache.pekko.http.cors.scaladsl.settings
 
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
 import pekko.http.scaladsl.model.{ HttpHeader, HttpMethod }
 import pekko.http.scaladsl.model.headers._
-import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
-
-import scala.collection.immutable.Seq
 
 /** INTERNAL API */
 final private[pekko] case class CorsSettingsImpl(

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/CorsDirectivesSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/CorsDirectivesSpec.scala
@@ -17,21 +17,23 @@
 
 package org.apache.pekko.http.cors
 
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
+import pekko.http.cors.scaladsl.CorsRejection
+import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
+import pekko.http.cors.scaladsl.settings.CorsSettings
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server.{ Directives, Route }
 import pekko.http.scaladsl.testkit.ScalatestRouteTest
-import pekko.http.cors.scaladsl.CorsRejection
-import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
-import pekko.http.cors.scaladsl.settings.CorsSettings
 
-import scala.collection.immutable.Seq
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class CorsDirectivesSpec extends AnyWordSpec with Matchers with Directives with ScalatestRouteTest {
   import HttpMethods._
+
   import pekko.http.cors.scaladsl.CorsDirectives._
 
   val actual = "actual"

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcherSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/model/HttpOriginMatcherSpec.scala
@@ -18,6 +18,7 @@
 package org.apache.pekko.http.cors.scaladsl.model
 
 import org.apache.pekko.http.scaladsl.model.headers.HttpOrigin
+
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/scaladsl/settings/CorsSettingsSpec.scala
@@ -18,13 +18,15 @@
 package org.apache.pekko.http.cors.scaladsl.settings
 
 import org.apache.pekko
-import pekko.http.scaladsl.model.headers.HttpOrigin
-import pekko.http.scaladsl.model.{ HttpMethod, HttpMethods }
-import pekko.http.scaladsl.testkit.ScalatestRouteTest
 import pekko.http.cors.scaladsl.model.{ HttpHeaderRange, HttpOriginMatcher }
-import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
+import pekko.http.scaladsl.model.{ HttpMethod, HttpMethods }
+import pekko.http.scaladsl.model.headers.HttpOrigin
+import pekko.http.scaladsl.testkit.ScalatestRouteTest
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
 
 class CorsSettingsSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
   import HttpMethods._

--- a/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonByteStringParserInput.scala
+++ b/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonByteStringParserInput.scala
@@ -15,10 +15,11 @@ package org.apache.pekko.http.scaladsl.marshallers.sprayjson
 
 import java.nio.charset.StandardCharsets
 
+import spray.json.ParserInput.IndexedBytesParserInput
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.util.ByteString
-import spray.json.ParserInput.IndexedBytesParserInput
 
 /**
  * INTERNAL API

--- a/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
+++ b/http-marshallers-scala/http-spray-json/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
@@ -13,22 +13,23 @@
 
 package org.apache.pekko.http.scaladsl.marshallers.sprayjson
 
+import scala.language.implicitConversions
+
+import spray.json._
+
 import org.apache.pekko
-import pekko.http.javadsl.{ common, model => jm }
 import pekko.NotUsed
 import pekko.event.Logging
+import pekko.http.javadsl.{ common, model => jm }
 import pekko.http.scaladsl.common.EntityStreamingSupport
 import pekko.http.scaladsl.marshalling._
-import pekko.http.scaladsl.model.MediaTypes.`application/json`
 import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import pekko.http.scaladsl.model.MediaTypes.`application/json`
 import pekko.http.scaladsl.unmarshalling.{ FromByteStringUnmarshaller, FromEntityUnmarshaller, Unmarshaller }
+import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import pekko.util.ByteString
-import spray.json._
-
-import scala.language.implicitConversions
 
 /**
  * A trait providing automatic to and from JSON marshalling/unmarshalling using an in-scope *spray-json* protocol.

--- a/http-marshallers-scala/http-spray-json/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/http-marshallers-scala/http-spray-json/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -15,17 +15,19 @@ package org.apache.pekko.http.scaladsl.marshallers.sprayjson
 
 import scala.concurrent.ExecutionContext
 
+import spray.json.{ JsArray, JsString, JsValue }
+import spray.json.RootJsonFormat
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.marshalling.Marshal
 import pekko.http.scaladsl.model.MessageEntity
 import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.util.ByteString
+
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import spray.json.{ JsArray, JsString, JsValue }
-import spray.json.RootJsonFormat
 
 class SprayJsonSupportSpec extends AnyWordSpec with Matchers with ScalaFutures {
   import SprayJsonSupport._

--- a/http-marshallers-scala/http-xml/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
+++ b/http-marshallers-scala/http-xml/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
@@ -15,13 +15,16 @@ package org.apache.pekko.http.scaladsl.marshallers.xml
 
 import java.io.{ ByteArrayInputStream, InputStreamReader }
 import javax.xml.parsers.{ SAXParser, SAXParserFactory }
+
 import scala.collection.immutable
 import scala.xml.{ NodeSeq, XML }
+
+import MediaTypes._
+
 import org.apache.pekko
-import pekko.http.scaladsl.unmarshalling._
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
-import MediaTypes._
+import pekko.http.scaladsl.unmarshalling._
 
 trait ScalaXmlSupport {
   implicit def defaultNodeSeqMarshaller: ToEntityMarshaller[NodeSeq] =

--- a/http-marshallers-scala/http-xml/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
+++ b/http-marshallers-scala/http-xml/src/main/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
@@ -19,11 +19,10 @@ import javax.xml.parsers.{ SAXParser, SAXParserFactory }
 import scala.collection.immutable
 import scala.xml.{ NodeSeq, XML }
 
-import MediaTypes._
-
 import org.apache.pekko
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.unmarshalling._
 
 trait ScalaXmlSupport {

--- a/http-scalafix/scalafix-rules/src/main/scala/org/apache/pekko/http/fix/MigrateToServerBuilder.scala
+++ b/http-scalafix/scalafix-rules/src/main/scala/org/apache/pekko/http/fix/MigrateToServerBuilder.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.http.fix
 
-import scalafix.lint.LintSeverity
-import scalafix.v1._
-
 import scala.meta._
 import scala.util.Try
+
+import scalafix.lint.LintSeverity
+import scalafix.v1._
 
 class MigrateToServerBuilder extends SemanticRule("MigrateToServerBuilder") {
 

--- a/http-testkit-munit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitTestFramework.scala
+++ b/http-testkit-munit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitTestFramework.scala
@@ -18,6 +18,7 @@
 package org.apache.pekko.http.scaladsl.testkit.munit
 
 import munit.FunSuite
+
 import org.apache.pekko.http.scaladsl.server.ExceptionHandler
 import org.apache.pekko.http.scaladsl.testkit.TestFrameworkInterface
 

--- a/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
+++ b/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
@@ -20,7 +20,6 @@ package org.apache.pekko.http.scaladsl.testkit.munit
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import Directives._
 import munit.FailException
 
 import org.apache.pekko
@@ -30,6 +29,7 @@ import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
 import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.Directives._
 import pekko.pattern.ask
 import pekko.stream.scaladsl.Source
 import pekko.testkit._

--- a/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
+++ b/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
@@ -21,12 +21,12 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import Directives._
-import HttpMethods._
 import munit.FailException
 
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
 import pekko.http.scaladsl.server._

--- a/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
+++ b/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
@@ -22,12 +22,12 @@ import scala.concurrent.duration._
 
 import Directives._
 import HttpMethods._
-import StatusCodes._
 import munit.FailException
 
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
 import pekko.http.scaladsl.server._
 import pekko.pattern.ask

--- a/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
+++ b/http-testkit-munit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/munit/MunitRouteTestSpec.scala
@@ -20,15 +20,16 @@ package org.apache.pekko.http.scaladsl.testkit.munit
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import org.apache.pekko
-import pekko.http.scaladsl.model._
+import Directives._
 import HttpMethods._
 import StatusCodes._
-import pekko.http.scaladsl.server._
-import Directives._
 import munit.FailException
-import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
+
+import org.apache.pekko
 import pekko.actor.ActorRef
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
+import pekko.http.scaladsl.server._
 import pekko.pattern.ask
 import pekko.stream.scaladsl.Source
 import pekko.testkit._

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/JUnitRouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/JUnitRouteTest.scala
@@ -13,6 +13,12 @@
 
 package org.apache.pekko.http.javadsl.testkit
 
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+import org.junit.{ Assert, Rule }
+import org.junit.rules.ExternalResource
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.Logging
@@ -20,11 +26,8 @@ import pekko.http.javadsl.model.HttpRequest
 import pekko.http.javadsl.server._
 import pekko.stream.Materializer
 import pekko.stream.SystemMaterializer
+
 import com.typesafe.config.{ Config, ConfigFactory }
-import org.junit.rules.ExternalResource
-import org.junit.{ Assert, Rule }
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
 
 /**
  * A RouteTest that uses JUnit assertions. ActorSystem and Materializer are provided as an [[org.junit.rules.ExternalResource]]

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/RouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/RouteTest.scala
@@ -17,18 +17,19 @@ import scala.annotation.varargs
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.impl.util.JavaMapping.Implicits.AddAsScala
 import pekko.http.javadsl.model.HttpRequest
 import pekko.http.javadsl.model.headers.Host
 import pekko.http.javadsl.server.{ AllDirectives, Directives, Route, RouteResult, RouteResults }
+import pekko.http.scaladsl
 import pekko.http.scaladsl.server
 import pekko.http.scaladsl.server.{ ExceptionHandler, Route => ScalaRoute }
 import pekko.http.scaladsl.settings.ParserSettings
 import pekko.http.scaladsl.settings.RoutingSettings
 import pekko.http.scaladsl.settings.ServerSettings
-import pekko.http.scaladsl
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.Materializer
 import pekko.testkit.TestDuration

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
@@ -19,13 +19,12 @@ import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-import RoutingJavaMapping._
-
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model._
 import pekko.http.javadsl.server.{ Rejection, RoutingJavaMapping }
+import pekko.http.javadsl.server.RoutingJavaMapping._
 import pekko.http.javadsl.server.RouteResult
 import pekko.http.javadsl.unmarshalling.Unmarshaller
 import pekko.http.scaladsl

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
@@ -23,8 +23,7 @@ import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model._
-import pekko.http.javadsl.server.{ Rejection, RoutingJavaMapping }
-import pekko.http.javadsl.server.RouteResult
+import pekko.http.javadsl.server.{ Rejection, RouteResult }
 import pekko.http.javadsl.server.RoutingJavaMapping._
 import pekko.http.javadsl.unmarshalling.Unmarshaller
 import pekko.http.scaladsl

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
@@ -24,8 +24,8 @@ import pekko.http.impl.util._
 import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model._
 import pekko.http.javadsl.server.{ Rejection, RoutingJavaMapping }
-import pekko.http.javadsl.server.RoutingJavaMapping._
 import pekko.http.javadsl.server.RouteResult
+import pekko.http.javadsl.server.RoutingJavaMapping._
 import pekko.http.javadsl.unmarshalling.Unmarshaller
 import pekko.http.scaladsl
 import pekko.http.scaladsl.model.HttpResponse

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/TestRouteResult.scala
@@ -13,25 +13,26 @@
 
 package org.apache.pekko.http.javadsl.testkit
 
-import org.apache.pekko
-import pekko.http.impl.util._
-import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.http.javadsl.model._
-import pekko.http.javadsl.server.RouteResult
-import pekko.http.javadsl.server.{ Rejection, RoutingJavaMapping }
-import pekko.http.javadsl.unmarshalling.Unmarshaller
-import RoutingJavaMapping._
-import pekko.http.scaladsl
-import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.http.scaladsl.model.HttpResponse
-import pekko.stream.Materializer
-import pekko.util.ByteString
-
 import scala.annotation.varargs
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
+
+import RoutingJavaMapping._
+
+import org.apache.pekko
+import pekko.http.impl.util._
+import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.http.javadsl.model._
+import pekko.http.javadsl.server.{ Rejection, RoutingJavaMapping }
+import pekko.http.javadsl.server.RouteResult
+import pekko.http.javadsl.unmarshalling.Unmarshaller
+import pekko.http.scaladsl
+import pekko.http.scaladsl.model.HttpResponse
+import pekko.http.scaladsl.unmarshalling.Unmarshal
+import pekko.stream.Materializer
+import pekko.util.ByteString
 
 /**
  * A wrapper for route results.

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/WSProbe.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/WSProbe.scala
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.http.javadsl.testkit
 
+import scala.concurrent.duration._
+import scala.jdk.DurationConverters._
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ActorSystem
@@ -23,9 +26,6 @@ import pekko.stream.Materializer
 import pekko.stream.javadsl.Flow
 import pekko.stream.scaladsl
 import pekko.util.ByteString
-
-import scala.concurrent.duration._
-import scala.jdk.DurationConverters._
 
 /**
  * A WSProbe is a probe that implements a `Flow[Message, Message, Unit]` for testing

--- a/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/WSTestRequestBuilding.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/javadsl/testkit/WSTestRequestBuilding.scala
@@ -13,16 +13,16 @@
 
 package org.apache.pekko.http.javadsl.testkit
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.pekko
 import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.http.javadsl.model.ws.Message
 import pekko.http.javadsl.model.{ HttpRequest, Uri }
+import pekko.http.javadsl.model.ws.Message
 import pekko.http.scaladsl.{ model => sm }
 import pekko.http.scaladsl.{ testkit => st }
 import pekko.stream.{ scaladsl, Materializer }
 import pekko.stream.javadsl.Flow
-
-import scala.jdk.CollectionConverters._
 
 trait WSTestRequestBuilding {
 

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/MarshallingTestUtils.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/MarshallingTestUtils.scala
@@ -13,18 +13,19 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.duration._
+import scala.util.Try
+
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.marshalling._
-import pekko.http.scaladsl.model.headers.Accept
 import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse, MediaRange }
+import pekko.http.scaladsl.model.headers.Accept
 import pekko.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshal }
 import pekko.stream.Materializer
-import com.typesafe.config.Config
 
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext }
-import scala.util.Try
+import com.typesafe.config.Config
 
 trait MarshallingTestUtils {
 

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTest.scala
@@ -13,12 +13,18 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import scala.collection.immutable
+import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future }
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+import scala.util.DynamicVariable
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.client.RequestBuilding
-import pekko.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import pekko.http.scaladsl.model.headers.{ `Sec-WebSocket-Protocol`, Host, Upgrade }
 import pekko.http.scaladsl.server._
 import pekko.http.scaladsl.settings.ParserSettings
@@ -30,13 +36,8 @@ import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.stream.scaladsl.Source
 import pekko.testkit.TestKit
 import pekko.util.ConstantFun
-import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.collection.immutable
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future }
-import scala.reflect.ClassTag
-import scala.util.DynamicVariable
+import com.typesafe.config.{ Config, ConfigFactory }
 
 trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTestResultComponent
     with MarshallingTestUtils {

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -17,13 +17,14 @@ import java.util.concurrent.CountDownLatch
 
 import scala.collection.immutable
 import scala.concurrent.duration._
+
 import org.apache.pekko
-import pekko.stream.Materializer
-import pekko.stream.scaladsl._
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import pekko.http.scaladsl.server._
-import pekko.http.scaladsl.model._
-import pekko.http.impl.util._
+import pekko.stream.Materializer
+import pekko.stream.scaladsl._
 
 trait RouteTestResultComponent {
 

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestTimeout.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/RouteTestTimeout.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.testkit
 
 import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.testkit._

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestUtils.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestUtils.scala
@@ -13,16 +13,17 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.util.Try
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.HttpEntity
 import pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import pekko.stream.Materializer
-import org.scalatest.Suite
-import org.scalatest.matchers.Matcher
 
-import scala.concurrent.{ Await, ExecutionContext, Future }
-import scala.util.Try
+import org.scalatest.Suite
 import org.scalatest.matchers
+import org.scalatest.matchers.Matcher
 
 trait ScalatestUtils extends MarshallingTestUtils {
   import matchers.should.Matchers._

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/Specs2Utils.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/Specs2Utils.scala
@@ -13,18 +13,19 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.AnyMatchers._
+import org.specs2.matcher.ExceptionMatchers._
+import org.specs2.matcher.FutureMatchers._
+import org.specs2.matcher.Matcher
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.HttpEntity
 import pekko.http.scaladsl.unmarshalling._
 import pekko.stream.Materializer
-import org.specs2.concurrent.ExecutionEnv
-import org.specs2.matcher.ExceptionMatchers._
-import org.specs2.matcher.FutureMatchers._
-import org.specs2.matcher.AnyMatchers._
-import org.specs2.matcher.Matcher
-
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.Try
 
 trait Specs2Utils extends MarshallingTestUtils {
 

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/TestFrameworkInterface.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/TestFrameworkInterface.scala
@@ -14,8 +14,9 @@
 package org.apache.pekko.http.scaladsl.testkit
 
 import org.apache.pekko.http.scaladsl.server.ExceptionHandler
-import org.scalatest.exceptions.TestFailedException
+
 import org.scalatest.{ BeforeAndAfterAll, Suite }
+import org.scalatest.exceptions.TestFailedException
 
 //#source-quote
 trait TestFrameworkInterface {

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/WSProbe.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/WSProbe.scala
@@ -13,21 +13,17 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
-import org.apache.pekko
-import pekko.NotUsed
-
 import scala.concurrent.duration._
 
-import pekko.util.ByteString
-
+import org.apache.pekko
+import pekko.NotUsed
 import pekko.actor.ActorSystem
-
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model.ws.{ BinaryMessage, Message, TextMessage }
 import pekko.stream.Materializer
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import pekko.stream.testkit.{ TestPublisher, TestSubscriber }
-
-import pekko.http.impl.util._
-import pekko.http.scaladsl.model.ws.{ BinaryMessage, Message, TextMessage }
+import pekko.util.ByteString
 
 /**
  * A WSProbe is a probe that implements a `Flow[Message, Message, Unit]` for testing

--- a/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/WSTestRequestBuilding.scala
+++ b/http-testkit/src/main/scala/org/apache/pekko/http/scaladsl/testkit/WSTestRequestBuilding.scala
@@ -13,13 +13,14 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.http.impl.engine.server.InternalCustomHeader
-import pekko.http.scaladsl.model.headers.{ `Sec-WebSocket-Protocol`, Upgrade, UpgradeProtocol }
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes, Uri }
-import pekko.http.scaladsl.model.ws.{ Message, WebSocketUpgrade }
 import pekko.http.scaladsl.model.AttributeKeys.webSocketUpgrade
-import scala.collection.immutable
+import pekko.http.scaladsl.model.headers.{ `Sec-WebSocket-Protocol`, Upgrade, UpgradeProtocol }
+import pekko.http.scaladsl.model.ws.{ Message, WebSocketUpgrade }
 import pekko.stream.{ FlowShape, Graph, Materializer }
 import pekko.stream.scaladsl.Flow
 

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -18,12 +18,13 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import Directives._
-import HttpMethods._
 import headers.`X-Forwarded-Proto`
 
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.scaladsl.server._

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -17,17 +17,15 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import Directives._
-import headers.`X-Forwarded-Proto`
-
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.StatusCodes._
-import pekko.http.scaladsl.model.headers.RawHeader
+import pekko.http.scaladsl.model.headers.{ RawHeader, `X-Forwarded-Proto` }
 import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.Directives._
 import pekko.pattern.ask
 import pekko.stream.scaladsl.Source
 import pekko.testkit._

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -13,25 +13,27 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
-import scala.concurrent.duration._
-import org.apache.pekko
-import pekko.testkit._
-import pekko.util.{ ByteString, Timeout }
-import pekko.pattern.ask
-import pekko.http.scaladsl.model.headers.RawHeader
-import pekko.http.scaladsl.server._
-import pekko.http.scaladsl.model._
-import StatusCodes._
-import HttpMethods._
-import Directives._
-import pekko.actor.ActorRef
-import pekko.stream.scaladsl.Source
-import org.scalatest.exceptions.TestFailedException
-import headers.`X-Forwarded-Proto`
-import org.scalatest.concurrent.ScalaFutures
-
 import scala.concurrent.Await
 import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import Directives._
+import HttpMethods._
+import StatusCodes._
+import headers.`X-Forwarded-Proto`
+
+import org.apache.pekko
+import pekko.actor.ActorRef
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.RawHeader
+import pekko.http.scaladsl.server._
+import pekko.pattern.ask
+import pekko.stream.scaladsl.Source
+import pekko.testkit._
+import pekko.util.{ ByteString, Timeout }
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -22,7 +22,6 @@ import pekko.actor.ActorRef
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
-import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
 import pekko.http.scaladsl.server._
 import pekko.http.scaladsl.server.Directives._

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -23,7 +23,7 @@ import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.StatusCodes._
-import pekko.http.scaladsl.model.headers.{ RawHeader, `X-Forwarded-Proto` }
+import pekko.http.scaladsl.model.headers.{ `X-Forwarded-Proto`, RawHeader }
 import pekko.http.scaladsl.server._
 import pekko.http.scaladsl.server.Directives._
 import pekko.pattern.ask

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -19,12 +19,12 @@ import scala.concurrent.duration._
 
 import Directives._
 import HttpMethods._
-import StatusCodes._
 import headers.`X-Forwarded-Proto`
 
 import org.apache.pekko
 import pekko.actor.ActorRef
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.scaladsl.server._
 import pekko.pattern.ask

--- a/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/Specs2RouteTestSpec.scala
+++ b/http-testkit/src/test/scala/org/apache/pekko/http/scaladsl/testkit/Specs2RouteTestSpec.scala
@@ -13,20 +13,21 @@
 
 package org.apache.pekko.http.scaladsl.testkit
 
+import scala.concurrent.duration._
+
+import org.specs2.mutable.Specification
+
 import org.apache.pekko
 import pekko.actor.ActorRef
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
-import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.RawHeader
-import pekko.http.scaladsl.server.Directives._
 import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.Directives._
 import pekko.pattern.ask
 import pekko.testkit.TestProbe
 import pekko.util.Timeout
-import org.specs2.mutable.Specification
-
-import scala.concurrent.duration._
 
 class Specs2RouteTestSpec extends Specification with Specs2RouteTest {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/javadsl/DirectivesConsistencySpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/javadsl/DirectivesConsistencySpec.scala
@@ -15,11 +15,12 @@ package org.apache.pekko.http.javadsl
 
 import java.lang.reflect.{ Method, Modifier }
 
+import scala.util.control.NoStackTrace
+
 import org.apache.pekko
 import pekko.http.javadsl.server.directives.CorrespondsTo
-import org.scalatest.exceptions.TestPendingException
 
-import scala.util.control.NoStackTrace
+import org.scalatest.exceptions.TestPendingException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/javadsl/server/HttpAppSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/javadsl/server/HttpAppSpec.scala
@@ -15,8 +15,12 @@ package org.apache.pekko.http.javadsl.server
 
 import java.net.InetSocketAddress
 import java.net.ServerSocket
-import java.util.concurrent.{ TimeUnit, TimeoutException }
 import java.net.SocketException
+import java.util.concurrent.{ TimeUnit, TimeoutException }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+
 import org.apache.pekko
 import pekko.Done
 import pekko.http.impl.util.PekkoSpecWithMaterializer
@@ -26,11 +30,10 @@ import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.client.RequestBuilding
 import pekko.http.scaladsl.model.{ HttpRequest, StatusCodes }
 import pekko.testkit.EventFilter
-import com.typesafe.config.ConfigFactory
+
 import org.scalatest.concurrent.Eventually
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, Future }
+import com.typesafe.config.ConfigFactory
 
 class HttpAppSpec extends PekkoSpecWithMaterializer with RequestBuilding with Eventually {
   import system.dispatcher

--- a/http-tests/src/test/scala/org/apache/pekko/http/javadsl/server/directives/SampleCustomHeader.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/javadsl/server/directives/SampleCustomHeader.scala
@@ -13,9 +13,9 @@
 
 package org.apache.pekko.http.javadsl.server.directives
 
-import org.apache.pekko.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion }
-
 import scala.util.{ Success, Try }
+
+import org.apache.pekko.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion }
 
 // no support for modeled headers in the Java DSL yet, so this has to live here
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -20,6 +20,7 @@ import pekko.http.scaladsl.client.RequestBuilding
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.MediaType.WithFixedCharset
 import pekko.http.scaladsl.server.Directives
+import pekko.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 import pekko.testkit._
 import pekko.util.ByteString
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -47,8 +47,7 @@ class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
     "allow registering custom media type" in {
       import system.dispatcher
 
-      // #application-custom      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`      import org.apache.pekko
-      import pekko.http.scaladsl.settings.ParserSettings
+      // #application-custom      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`      import org.apache.pekko      import pekko.http.scaladsl.settings.ParserSettings
       import pekko.http.scaladsl.settings.ServerSettings
 
       // define custom media type:

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -17,8 +17,8 @@ import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.http.scaladsl.client.RequestBuilding
-import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.MediaType.WithFixedCharset
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.server.Directives
 import pekko.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 import pekko.testkit._
@@ -45,10 +45,16 @@ class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
       set.contains(MediaType.parse("application/x-Akka-TEST").right.get) should ===(true)
     }
 
+    // need to disable scalafix here because the code is used in the docs
+    // scalafix:off
     "allow registering custom media type" in {
       import system.dispatcher
+      // #application-custom
 
-      // #application-custom      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`      import org.apache.pekko      import pekko.http.scaladsl.settings.ParserSettings      import pekko.http.scaladsl.settings.ServerSettings
+      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`
+      import org.apache.pekko
+      import pekko.http.scaladsl.settings.ParserSettings
+      import pekko.http.scaladsl.settings.ServerSettings
 
       // define custom media type:
       val utf8 = HttpCharsets.`UTF-8`

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -34,7 +34,7 @@ class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
       set.add(MediaTypes.`application/vnd.ms-excel`)
       set.add(MediaTypes.`application/vnd.ms-powerpoint`)
       set.add(MediaTypes.`application/msword`)
-      set.add(MediaType.customBinary("application", "x-Akka-TEST", MediaType.NotCompressible))
+      set.add(MediaType.customBinary("application", "x-Pekko-TEST", MediaType.NotCompressible))
 
       set.contains(MediaType.parse("application/msword").right.get) should ===(true)
       set.contains(MediaType.parse("application/MsWord").right.get) should ===(true)

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -47,8 +47,7 @@ class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
     "allow registering custom media type" in {
       import system.dispatcher
 
-      // #application-custom      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`      import org.apache.pekko      import pekko.http.scaladsl.settings.ParserSettings
-      import pekko.http.scaladsl.settings.ServerSettings
+      // #application-custom      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`      import org.apache.pekko      import pekko.http.scaladsl.settings.ParserSettings      import pekko.http.scaladsl.settings.ServerSettings
 
       // define custom media type:
       val utf8 = HttpCharsets.`UTF-8`

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -13,15 +13,17 @@
 
 package org.apache.pekko.http.scaladsl
 
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.scaladsl.client.RequestBuilding
-import pekko.http.scaladsl.model.MediaType.WithFixedCharset
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaType.WithFixedCharset
 import pekko.http.scaladsl.server.Directives
 import pekko.testkit._
 import pekko.util.ByteString
+
 import org.scalatest.concurrent.ScalaFutures
-import scala.concurrent.duration._
 
 class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
     with Directives with RequestBuilding {
@@ -44,10 +46,8 @@ class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
 
     "allow registering custom media type" in {
       import system.dispatcher
-      // #application-custom
 
-      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`
-      import org.apache.pekko
+      // #application-custom      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`      import org.apache.pekko
       import pekko.http.scaladsl.settings.ParserSettings
       import pekko.http.scaladsl.settings.ServerSettings
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomMediaTypesSpec.scala
@@ -17,10 +17,9 @@ import scala.concurrent.duration._
 
 import org.apache.pekko
 import pekko.http.scaladsl.client.RequestBuilding
-import pekko.http.scaladsl.model.MediaType.WithFixedCharset
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaType.WithFixedCharset
 import pekko.http.scaladsl.server.Directives
-import pekko.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 import pekko.testkit._
 import pekko.util.ByteString
 
@@ -41,18 +40,15 @@ class CustomMediaTypesSpec extends PekkoSpec with ScalaFutures
       set.contains(MediaType.parse("application/MsWord").right.get) should ===(true)
       set.contains(MediaType.parse("application/vnd.ms-POWERPOINT").right.get) should ===(true)
       set.contains(MediaType.parse("application/VnD.MS-eXceL").right.get) should ===(true)
-      set.contains(MediaType.parse("application/x-akka-test").right.get) should ===(true)
-      set.contains(MediaType.parse("application/x-Akka-TEST").right.get) should ===(true)
+      set.contains(MediaType.parse("application/x-pekko-test").right.get) should ===(true)
+      set.contains(MediaType.parse("application/x-Pekko-TEST").right.get) should ===(true)
     }
 
-    // need to disable scalafix here because the code is used in the docs
-    // scalafix:off
     "allow registering custom media type" in {
-      import system.dispatcher
       // #application-custom
 
-      // similarly in Java: `org.apache.pekko.http.javadsl.settings.[...]`
-      import org.apache.pekko
+      import system.dispatcher
+
       import pekko.http.scaladsl.settings.ParserSettings
       import pekko.http.scaladsl.settings.ServerSettings
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/CustomStatusCodesSpec.scala
@@ -19,6 +19,7 @@ import pekko.http.scaladsl.client.RequestBuilding
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.server.Directives
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
+
 import org.scalatest.concurrent.ScalaFutures
 
 class CustomStatusCodesSpec extends PekkoSpecWithMaterializer with ScalaFutures

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/FormDataSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/FormDataSpec.scala
@@ -14,9 +14,9 @@
 package org.apache.pekko.http.scaladsl
 
 import org.apache.pekko
-import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.http.scaladsl.marshalling.Marshal
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.testkit.PekkoSpec
 
 class FormDataSpec extends PekkoSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
@@ -17,6 +17,7 @@ import java.util.function.Supplier
 
 import org.apache.pekko
 import pekko.http.javadsl.server.Route
+
 import org.scalatest.wordspec.AnyWordSpec
 
 class RouteJavaScalaDslConversionSpec extends AnyWordSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/TestSingleRequest.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/TestSingleRequest.scala
@@ -13,14 +13,16 @@
 
 package org.apache.pekko.http.scaladsl
 
-import org.apache.pekko
-import pekko.http.scaladsl.model.HttpRequest
-import pekko.util.ByteString
-import com.typesafe.config.{ Config, ConfigFactory }
-import pekko.actor.ActorSystem
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.io.StdIn
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.model.HttpRequest
+import pekko.util.ByteString
+
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object TestSingleRequest extends App {
   val testConf: Config = ConfigFactory.parseString("""

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/CodecSpecSupport.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/CodecSpecSupport.scala
@@ -13,11 +13,12 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
-import org.scalatest.{ BeforeAndAfterAll, Suite }
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.testkit.TestKit
 import pekko.util.ByteString
+
+import org.scalatest.{ BeforeAndAfterAll, Suite }
 import org.scalatest.matchers.should.Matchers
 
 trait CodecSpecSupport extends Matchers with BeforeAndAfterAll { self: Suite =>

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/CoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/CoderSpec.scala
@@ -14,26 +14,26 @@
 package org.apache.pekko.http.scaladsl.coding
 
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream }
+import java.util.concurrent.ThreadLocalRandom
 import java.util.zip.DataFormatException
+
+import scala.annotation.nowarn
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 import org.apache.pekko
 import pekko.NotUsed
-
-import scala.annotation.tailrec
-import scala.concurrent.duration._
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
-import java.util.concurrent.ThreadLocalRandom
-
-import scala.util.control.NoStackTrace
-import org.scalatest.Inspectors
-import pekko.util.ByteString
-import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.http.impl.util._
 import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest }
 import pekko.http.scaladsl.model.HttpMethods._
-import pekko.http.impl.util._
+import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.testkit._
-import scala.annotation.nowarn
+import pekko.util.ByteString
+
+import org.scalatest.Inspectors
 import org.scalatest.wordspec.AnyWordSpec
 
 @nowarn("msg=deprecated .* is internal API")

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
@@ -17,11 +17,11 @@ import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 import HttpMethods.POST
-import headers._
 
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.stream.{ Attributes, FlowShape }
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import pekko.stream.stage._

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
@@ -13,19 +13,21 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
+import scala.annotation.nowarn
+import scala.concurrent.duration._
+
+import HttpMethods.POST
+import headers._
+
 import org.apache.pekko
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
 import pekko.stream.{ Attributes, FlowShape }
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
-
-import scala.concurrent.duration._
-import pekko.util.ByteString
 import pekko.stream.stage._
-import pekko.http.scaladsl.model._
-import pekko.http.impl.util._
 import pekko.testkit._
-import headers._
-import HttpMethods.POST
-import scala.annotation.nowarn
+import pekko.util.ByteString
+
 import org.scalatest.wordspec.AnyWordSpec
 
 class DecoderSpec extends AnyWordSpec with CodecSpecSupport {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DecoderSpec.scala
@@ -16,11 +16,10 @@ package org.apache.pekko.http.scaladsl.coding
 import scala.annotation.nowarn
 import scala.concurrent.duration._
 
-import HttpMethods.POST
-
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpMethods.POST
 import pekko.http.scaladsl.model.headers._
 import pekko.stream.{ Attributes, FlowShape }
 import pekko.stream.impl.fusing.GraphStages.SimpleLinearGraphStage

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/DeflateSpec.scala
@@ -13,20 +13,20 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
-import org.apache.pekko
-import pekko.util.ByteString
 import java.io.{ InputStream, OutputStream }
 import java.util.zip._
 
-import pekko.http.scaladsl.model.HttpMethods.POST
-import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest }
+import scala.annotation.nowarn
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+import org.apache.pekko
 import pekko.http.impl.util._
+import pekko.http.scaladsl.model.{ HttpEntity, HttpRequest }
+import pekko.http.scaladsl.model.HttpMethods.POST
 import pekko.http.scaladsl.model.headers.{ `Content-Encoding`, HttpEncodings }
 import pekko.testkit._
-import scala.annotation.nowarn
-
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
+import pekko.util.ByteString
 
 class DeflateSpec extends CoderSpec {
   protected def Coder: Coder = Coders.Deflate

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/EncoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/EncoderSpec.scala
@@ -17,11 +17,11 @@ import scala.annotation.nowarn
 import scala.concurrent.duration._
 
 import HttpMethods.POST
-import headers._
 
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.testkit._
 import pekko.util.ByteString
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/EncoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/EncoderSpec.scala
@@ -13,18 +13,19 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
-import org.apache.pekko
-import pekko.util.ByteString
-import pekko.http.scaladsl.model._
-import headers._
-import HttpMethods.POST
-
-import scala.concurrent.duration._
-import pekko.http.impl.util._
-import pekko.testkit._
-import org.scalatest.wordspec.AnyWordSpec
-
 import scala.annotation.nowarn
+import scala.concurrent.duration._
+
+import HttpMethods.POST
+import headers._
+
+import org.apache.pekko
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
+import pekko.testkit._
+import pekko.util.ByteString
+
+import org.scalatest.wordspec.AnyWordSpec
 
 class EncoderSpec extends AnyWordSpec with CodecSpecSupport {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/EncoderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/EncoderSpec.scala
@@ -16,11 +16,10 @@ package org.apache.pekko.http.scaladsl.coding
 import scala.annotation.nowarn
 import scala.concurrent.duration._
 
-import HttpMethods.POST
-
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpMethods.POST
 import pekko.http.scaladsl.model.headers._
 import pekko.testkit._
 import pekko.util.ByteString

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/GzipSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/coding/GzipSpec.scala
@@ -16,10 +16,11 @@ package org.apache.pekko.http.scaladsl.coding
 import java.io.{ InputStream, OutputStream }
 import java.util.zip.{ GZIPInputStream, GZIPOutputStream, ZipException }
 
+import scala.annotation.nowarn
+
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.util.ByteString
-import scala.annotation.nowarn
 
 @nowarn("msg=deprecated .* is internal API")
 class GzipSpec extends CoderSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/JsonSupportSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/JsonSupportSpec.scala
@@ -14,11 +14,12 @@
 package org.apache.pekko.http.scaladsl.marshallers
 
 import org.apache.pekko
+import pekko.http.impl.util._
 import pekko.http.scaladsl.marshalling.ToEntityMarshaller
 import pekko.http.scaladsl.model.{ HttpCharsets, HttpEntity, MediaTypes }
 import pekko.http.scaladsl.testkit.ScalatestRouteTest
 import pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
-import pekko.http.impl.util._
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -15,14 +15,15 @@ package org.apache.pekko.http.scaladsl.marshallers.sprayjson
 
 import java.lang.StringBuilder
 
+import scala.collection.immutable.ListMap
+
+import spray.json.{ DefaultJsonProtocol, JsValue, JsonPrinter, PrettyPrinter }
+import spray.json.RootJsonFormat
+
 import org.apache.pekko
 import pekko.http.scaladsl.marshallers.{ Employee, JsonSupportSpec }
 import pekko.http.scaladsl.marshalling.ToEntityMarshaller
 import pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
-import spray.json.{ DefaultJsonProtocol, JsValue, JsonPrinter, PrettyPrinter }
-
-import scala.collection.immutable.ListMap
-import spray.json.RootJsonFormat
 
 class SprayJsonSupportSpec extends JsonSupportSpec {
   object EmployeeJsonProtocol extends DefaultJsonProtocol {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
@@ -16,20 +16,22 @@ package org.apache.pekko.http.scaladsl.marshallers.xml
 import java.io.File
 import java.nio.file.Files
 
-import org.xml.sax.SAXParseException
-
-import scala.xml.NodeSeq
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import org.scalatest.Inside
+import scala.xml.NodeSeq
+
+import MediaTypes._
+import org.xml.sax.SAXParseException
+
 import org.apache.pekko
-import pekko.util.ByteString
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.testkit.ScalatestRouteTest
 import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.http.scaladsl.model._
-import pekko.testkit._
-import MediaTypes._
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import pekko.testkit._
+import pekko.util.ByteString
+
+import org.scalatest.Inside
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
@@ -20,11 +20,11 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.xml.NodeSeq
 
-import MediaTypes._
 import org.xml.sax.SAXParseException
 
 import org.apache.pekko
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.testkit.ScalatestRouteTest
 import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -15,16 +15,19 @@ package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.apache.pekko
-import pekko.http.scaladsl.server.MediaTypeNegotiator
-import pekko.http.scaladsl.server.ContentNegotiator.Alternative
-import pekko.util.ByteString
-import pekko.http.scaladsl.util.FastFuture._
-import pekko.http.scaladsl.model._
-import pekko.http.impl.util._
-import MediaTypes._
+
 import HttpCharsets._
+import MediaTypes._
+
+import org.apache.pekko
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.server.ContentNegotiator.Alternative
+import pekko.http.scaladsl.server.MediaTypeNegotiator
 import pekko.http.scaladsl.server.util.VarArgsFunction1
+import pekko.http.scaladsl.util.FastFuture._
+import pekko.util.ByteString
+
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -16,12 +16,11 @@ package org.apache.pekko.http.scaladsl.marshalling
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import HttpCharsets._
-import MediaTypes._
-
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpCharsets._
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.server.ContentNegotiator.Alternative
 import pekko.http.scaladsl.server.MediaTypeNegotiator
 import pekko.http.scaladsl.server.util.VarArgsFunction1

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/FromStatusCodeAndXYZMarshallerSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/FromStatusCodeAndXYZMarshallerSpec.scala
@@ -13,13 +13,14 @@
 
 package org.apache.pekko.http.scaladsl.marshalling
 
+import spray.json.RootJsonFormat
+
 import org.apache.pekko
 import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import pekko.http.scaladsl.model.{ ContentTypes, MediaRanges, MediaTypes }
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers.Accept
-import pekko.http.scaladsl.model.{ ContentTypes, MediaRanges, MediaTypes }
 import pekko.http.scaladsl.server.{ Route, RoutingSpec }
-import spray.json.RootJsonFormat
 
 class FromStatusCodeAndXYZMarshallerSpec extends RoutingSpec {
   case class ErrorInfo(errorMessage: String)

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -13,25 +13,27 @@
 
 package org.apache.pekko.http.scaladsl.marshalling
 
+import scala.collection.immutable
+import scala.collection.immutable.ListMap
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.impl.util._
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport._
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpCharsets._
 import pekko.http.scaladsl.model.MediaTypes._
-import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.testkit.MarshallingTestUtils
 import pekko.stream.scaladsl.Source
 import pekko.testkit.TestKit
 import pekko.util.ByteString
-import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
 
-import scala.collection.immutable
-import scala.collection.immutable.ListMap
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import com.typesafe.config.ConfigFactory
 
 class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers
     with MarshallingTestUtils {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/sse/EventStreamMarshallingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/marshalling/sse/EventStreamMarshallingSpec.scala
@@ -16,6 +16,9 @@ package scaladsl
 package marshalling
 package sse
 
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.MediaTypes.`text/event-stream`
 import pekko.http.scaladsl.model.sse.ServerSentEvent
@@ -23,13 +26,13 @@ import pekko.http.scaladsl.server.Directives
 import pekko.http.scaladsl.testkit.RouteTest
 import pekko.http.scaladsl.testkit.TestFrameworkInterface.Scalatest
 import pekko.stream.scaladsl.{ Sink, Source }
-import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 final class EventStreamMarshallingSpec extends AnyWordSpec with Matchers with RouteTest with Scalatest {
   import Directives._
+
   import pekko.http.scaladsl.marshalling.sse.EventStreamMarshalling._
 
   "A source of ServerSentEvents" should {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/BasicRouteSpecs.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/BasicRouteSpecs.scala
@@ -13,11 +13,9 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import model.HttpMethods._
-import model.StatusCodes
-
 import org.apache.pekko
-import pekko.http.scaladsl.model
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.model.StatusCodes
 import pekko.testkit.EventFilter
 
 object BasicRouteSpecs {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/BasicRouteSpecs.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/BasicRouteSpecs.scala
@@ -13,10 +13,11 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import org.apache.pekko
-import pekko.http.scaladsl.model
 import model.HttpMethods._
 import model.StatusCodes
+
+import org.apache.pekko
+import pekko.http.scaladsl.model
 import pekko.testkit.EventFilter
 
 object BasicRouteSpecs {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/ConnectionTestApp.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/ConnectionTestApp.scala
@@ -13,17 +13,18 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.concurrent.Future
+import scala.io.StdIn
+import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
 import pekko.actor._
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
-import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.OverflowStrategy
-import com.typesafe.config.{ Config, ConfigFactory }
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
 
-import scala.concurrent.Future
-import scala.io.StdIn
-import scala.util.{ Failure, Success, Try }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object ConnectionTestApp {
   val testConf: Config = ConfigFactory.parseString("""

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DiscardEntityDefaultExceptionHandlerSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DiscardEntityDefaultExceptionHandlerSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.http.impl.util.WithLogCapturing
 import pekko.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
@@ -20,10 +22,9 @@ import pekko.http.scaladsl.model.HttpEntity
 import pekko.http.scaladsl.model.StatusCodes.InternalServerError
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
+
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.ScalaFutures
-
-import scala.concurrent.Future
 
 class DiscardEntityDefaultExceptionHandlerSpec extends RoutingSpec with ScalaFutures with WithLogCapturing {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DiscardEntityDefaultRejectionHandlerSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DiscardEntityDefaultRejectionHandlerSpec.scala
@@ -19,6 +19,7 @@ import pekko.http.scaladsl.model.HttpEntity
 import pekko.http.scaladsl.model.StatusCodes.NotFound
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
+
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.ScalaFutures
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -14,7 +14,13 @@
 package org.apache.pekko.http.scaladsl.server
 
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
+import org.apache.pekko.stream.Materializer
 import pekko.actor.ActorSystem
 import pekko.event.{ LogSource, Logging }
 import pekko.http.impl.util.WithLogCapturing
@@ -23,15 +29,12 @@ import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.Utils.assertAllStagesStopped
 import pekko.testkit.TestKit
-import com.typesafe.config.ConfigFactory
-import org.apache.pekko.stream.Materializer
-import org.scalatest.BeforeAndAfterAll
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.util.{ Failure, Success, Try }
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+
+import com.typesafe.config.ConfigFactory
 
 abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String)
     extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with WithLogCapturing {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/EntityStreamingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/EntityStreamingSpec.scala
@@ -16,6 +16,8 @@ package org.apache.pekko.http.scaladsl.server
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
+import spray.json.{ DefaultJsonProtocol, RootJsonFormat }
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.http.scaladsl.common.{ EntityStreamingSupport, JsonEntityStreamingSupport }
@@ -27,7 +29,6 @@ import pekko.testkit._
 import pekko.util.ByteString
 
 import org.scalatest.concurrent.ScalaFutures
-import spray.json.{ DefaultJsonProtocol, RootJsonFormat }
 
 class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
   implicit override val patience: PatienceConfig = PatienceConfig(5.seconds.dilated(system), 200.millis)
@@ -111,10 +112,11 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
   "client-consume-streaming-json" in {
     // #json-streaming-client-example
     import MyJsonProtocol._
+
     import org.apache.pekko
-    import pekko.http.scaladsl.unmarshalling._
     import pekko.http.scaladsl.common.EntityStreamingSupport
     import pekko.http.scaladsl.common.JsonEntityStreamingSupport
+    import pekko.http.scaladsl.unmarshalling._
 
     implicit val jsonStreamingSupport: JsonEntityStreamingSupport =
       EntityStreamingSupport.json()
@@ -147,10 +149,11 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
   "client-consume-streaming-json-raw" in {
     // #json-streaming-client-example-raw
     import MyJsonProtocol._
+
     import org.apache.pekko
-    import pekko.http.scaladsl.unmarshalling._
     import pekko.http.scaladsl.common.EntityStreamingSupport
     import pekko.http.scaladsl.common.JsonEntityStreamingSupport
+    import pekko.http.scaladsl.unmarshalling._
 
     implicit val jsonStreamingSupport: JsonEntityStreamingSupport =
       EntityStreamingSupport.json()

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/HttpAppSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/HttpAppSpec.scala
@@ -15,26 +15,28 @@ package org.apache.pekko.http.scaladsl.server
 
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import java.net.SocketException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.net.SocketException
+
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.ActorSystem
 import pekko.http.impl.util.PekkoSpecWithMaterializer
-import pekko.http.scaladsl.Http.ServerBinding
 import pekko.http.scaladsl.Http
+import pekko.http.scaladsl.Http.ServerBinding
 import pekko.http.scaladsl.client.RequestBuilding
 import pekko.http.scaladsl.model.{ HttpRequest, StatusCodes }
 import pekko.http.scaladsl.settings.ServerSettings
 import pekko.testkit.EventFilter
-import com.typesafe.config.ConfigFactory
+
 import org.scalatest.concurrent.Eventually
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
-import scala.util.Try
+import com.typesafe.config.ConfigFactory
 
 class HttpAppSpec extends PekkoSpecWithMaterializer with RequestBuilding with Eventually {
   import system.dispatcher

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/ModeledCustomHeaderSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/ModeledCustomHeaderSpec.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.{ HttpRequest, StatusCodes }
 import pekko.http.scaladsl.model.headers._
-
-import scala.util.{ Failure, Success, Try }
 
 object ModeledCustomHeaderSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RejectionSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RejectionSpec.scala
@@ -13,8 +13,9 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import org.apache.pekko
 import scala.jdk.CollectionConverters._
+
+import org.apache.pekko
 
 class RejectionSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RouteResultSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RouteResultSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.annotation.nowarn
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
@@ -20,7 +22,7 @@ import pekko.http.scaladsl.server.Directives.complete
 import pekko.stream.Materializer
 import pekko.stream.scaladsl.Flow
 import pekko.testkit.TestKit
-import scala.annotation.nowarn
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RoutingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/RoutingSpec.scala
@@ -18,6 +18,7 @@ import pekko.http.impl.util.WithLogCapturing
 import pekko.http.scaladsl.model.HttpResponse
 import pekko.http.scaladsl.testkit.ScalatestRouteTest
 import pekko.testkit.TestKitBase
+
 import org.scalatest.Suite
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/SizeLimitSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/SizeLimitSpec.scala
@@ -13,29 +13,31 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.collection.immutable
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.client.RequestBuilding
 import pekko.http.scaladsl.coding.{ Coders, Decoder }
-import pekko.http.scaladsl.model.HttpEntity.Chunk
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpEntity.Chunk
 import pekko.http.scaladsl.model.headers.{ `Content-Encoding`, HttpEncoding, HttpEncodings }
 import pekko.http.scaladsl.server.Directives._
 import pekko.stream.scaladsl.{ Flow, Source }
 import pekko.testkit.TestKit
 import pekko.util.ByteString
-import com.typesafe.config.{ Config, ConfigFactory }
+
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.immutable
-import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
+import com.typesafe.config.{ Config, ConfigFactory }
 
 class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with BeforeAndAfterAll with ScalaFutures {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/TcpLeakApp.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/TcpLeakApp.scala
@@ -15,14 +15,16 @@ package org.apache.pekko.http.scaladsl.server
 
 import java.net.InetSocketAddress
 
+import scala.io.StdIn
+
 import org.apache.pekko
 import pekko.actor.{ ActorSystem, ActorSystemImpl }
 import pekko.event.Logging
-import pekko.stream.scaladsl._
 import pekko.stream.ActorAttributes
+import pekko.stream.scaladsl._
 import pekko.util.ByteString
+
 import com.typesafe.config.{ Config, ConfigFactory }
-import scala.io.StdIn
 
 object TcpLeakApp extends App {
   val testConf: Config = ConfigFactory.parseString(

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -16,12 +16,12 @@ package directives
 
 import java.util.concurrent.{ ThreadLocalRandom, TimeoutException }
 
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
-
-import scala.concurrent.duration._
 
 class BasicDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
@@ -14,7 +14,8 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers._
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
@@ -14,10 +14,9 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import StatusCodes._
-import headers._
-
 import org.apache.pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
 
 class CacheConditionDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
@@ -14,9 +14,10 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import org.apache.pekko.http.scaladsl.model._
 import StatusCodes._
 import headers._
+
+import org.apache.pekko.http.scaladsl.model._
 
 class CacheConditionDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -21,14 +21,14 @@ import HttpCharsets._
 import HttpEncodings._
 import HttpEntity.{ Chunk, ChunkStreamPart }
 import MediaTypes._
-import StatusCodes._
-import headers._
 
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.coding.Coders._
 import pekko.http.scaladsl.coding.Encoder
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.testkit.RouteTestTimeout
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.testkit._

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -14,26 +14,28 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import org.scalatest.Inside
-import org.scalatest.matchers.Matcher
-import org.apache.pekko
-import pekko.util.ByteString
-import pekko.stream.scaladsl.{ Sink, Source }
-import pekko.http.impl.util._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.coding.Encoder
-import pekko.http.scaladsl.coding.Coders._
-import pekko.testkit._
-import headers._
-import HttpEntity.{ Chunk, ChunkStreamPart }
+import scala.concurrent.duration._
+
+import ContentTypes.`application/octet-stream`
 import HttpCharsets._
 import HttpEncodings._
+import HttpEntity.{ Chunk, ChunkStreamPart }
 import MediaTypes._
 import StatusCodes._
-import ContentTypes.`application/octet-stream`
-import pekko.http.scaladsl.testkit.RouteTestTimeout
+import headers._
 
-import scala.concurrent.duration._
+import org.apache.pekko
+import pekko.http.impl.util._
+import pekko.http.scaladsl.coding.Coders._
+import pekko.http.scaladsl.coding.Encoder
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.testkit.RouteTestTimeout
+import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.testkit._
+import pekko.util.ByteString
+
+import org.scalatest.Inside
+import org.scalatest.matchers.Matcher
 
 class CodingDirectivesSpec extends RoutingSpec with Inside {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -16,19 +16,18 @@ package directives
 
 import scala.concurrent.duration._
 
-import ContentTypes.`application/octet-stream`
-import HttpCharsets._
-import HttpEncodings._
-import HttpEntity.{ Chunk, ChunkStreamPart }
-import MediaTypes._
-
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.coding.Coders._
 import pekko.http.scaladsl.coding.Encoder
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.ContentTypes.`application/octet-stream`
+import pekko.http.scaladsl.model.HttpCharsets._
+import pekko.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart }
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.model.headers.HttpEncodings._
 import pekko.http.scaladsl.testkit.RouteTestTimeout
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.testkit._

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectivesSpec.scala
@@ -14,9 +14,10 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import org.apache.pekko.http.scaladsl.model._
 import StatusCodes.OK
 import headers._
+
+import org.apache.pekko.http.scaladsl.model._
 
 class CookieDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectivesSpec.scala
@@ -14,9 +14,9 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import StatusCodes.OK
-
-import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes.OK
 import pekko.http.scaladsl.model.headers._
 
 class CookieDirectivesSpec extends RoutingSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectivesSpec.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import StatusCodes.OK
-import headers._
 
 import org.apache.pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 
 class CookieDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/ExecutionDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/ExecutionDirectivesSpec.scala
@@ -14,14 +14,15 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.http.scaladsl.coding.Coders
 import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.model.headers.HttpEncodings._
 import pekko.http.scaladsl.model.headers._
-
-import scala.concurrent.Future
+import pekko.http.scaladsl.model.headers.HttpEncodings._
 import pekko.testkit.EventFilter
+
 import org.scalatest.matchers.Matcher
 
 class ExecutionDirectivesSpec extends RoutingSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -21,13 +21,13 @@ import scala.concurrent.duration._
 import scala.util.Properties
 
 import org.apache.pekko
+import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.model.Uri.Path
-import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.settings.RoutingSettings
 import pekko.http.scaladsl.testkit.RouteTestTimeout
-import pekko.http.impl.util._
 import pekko.testkit._
 
 import org.scalatest.{ Inside, Inspectors }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -15,18 +15,19 @@ package org.apache.pekko.http.scaladsl.server.directives
 
 import java.io.File
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.http.scaladsl.model.{ Multipart, _ }
 import pekko.http.scaladsl.server.{ MissingFormFieldRejection, Route, RoutingSpec }
 import pekko.http.scaladsl.testkit.RouteTestTimeout
 import pekko.stream.scaladsl.Source
-import pekko.util.ByteString
 import pekko.testkit._
-import org.scalatest.concurrent.Eventually
+import pekko.util.ByteString
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
+import org.scalatest.concurrent.Eventually
 
 class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
@@ -473,11 +474,10 @@ class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
 /** Mock Path implementation that allows to create a FileChannel that fails writes */
 class MockFailingWritePath extends java.nio.file.Path { selfPath =>
+  import java.{ lang, util }
   import java.net.URI
   import java.nio.{ ByteBuffer, MappedByteBuffer }
   import java.nio.channels.{ FileChannel, FileLock, ReadableByteChannel, SeekableByteChannel, WritableByteChannel }
-  import java.nio.file.attribute.{ BasicFileAttributes, FileAttribute, FileAttributeView, UserPrincipalLookupService }
-  import java.nio.file.spi.FileSystemProvider
   import java.nio.file.{
     AccessMode,
     CopyOption,
@@ -492,7 +492,8 @@ class MockFailingWritePath extends java.nio.file.Path { selfPath =>
     WatchKey,
     WatchService
   }
-  import java.{ lang, util }
+  import java.nio.file.attribute.{ BasicFileAttributes, FileAttribute, FileAttributeView, UserPrincipalLookupService }
+  import java.nio.file.spi.FileSystemProvider
 
   override def getFileSystem: FileSystem =
     new FileSystem {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -14,17 +14,18 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.xml.NodeSeq
+
 import org.apache.pekko
-import pekko.stream.scaladsl.Source
 import pekko.http.HashCodeCollider
+import pekko.http.impl.util.BenchUtils
 import pekko.http.scaladsl.common.StrictForm
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import pekko.http.scaladsl.unmarshalling.Unmarshaller.HexInt
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.MediaTypes._
-import pekko.http.impl.util.BenchUtils
 import pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
-import scala.xml.NodeSeq
+import pekko.http.scaladsl.unmarshalling.Unmarshaller.HexInt
+import pekko.stream.scaladsl.Source
 
 class FormFieldDirectivesSpec extends RoutingSpec {
   implicit val nodeSeqUnmarshaller: FromEntityUnmarshaller[NodeSeq] =

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FutureDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FutureDirectivesSpec.scala
@@ -14,15 +14,15 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.StatusCodes
 import pekko.pattern.CircuitBreaker
-
-import scala.concurrent.Future
 import pekko.testkit._
-import org.scalatest.Inside
 
-import scala.concurrent.duration._
+import org.scalatest.Inside
 
 class FutureDirectivesSpec extends RoutingSpec with Inside with TestKitBase {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -16,12 +16,11 @@ package org.apache.pekko.http.scaladsl.server.directives
 import scala.reflect.ClassTag
 import scala.util.Try
 
-import directives.HeaderDirectivesSpec.XCustomHeader
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.directives.HeaderDirectivesSpec.XCustomHeader
 
 import org.scalatest.Inside
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -17,10 +17,10 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 import directives.HeaderDirectivesSpec.XCustomHeader
-import headers._
 
 import org.apache.pekko
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server._
 
 import org.scalatest.Inside

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -13,15 +13,17 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
-import org.apache.pekko
-import pekko.http.scaladsl.model._
-import headers._
-import pekko.http.scaladsl.server._
-import directives.HeaderDirectivesSpec.XCustomHeader
-
-import org.scalatest.Inside
 import scala.reflect.ClassTag
 import scala.util.Try
+
+import directives.HeaderDirectivesSpec.XCustomHeader
+import headers._
+
+import org.apache.pekko
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.server._
+
+import org.scalatest.Inside
 
 class HeaderDirectivesSpec extends RoutingSpec with Inside {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HostDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/HostDirectivesSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import org.apache.pekko.http.scaladsl.model.headers.Host
+
 import org.scalatest.freespec.AnyFreeSpec
 
 class HostDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
@@ -16,22 +16,23 @@ package directives
 
 import scala.concurrent.Future
 import scala.util.{ Failure, Try }
-
 import scala.xml.NodeSeq
-import org.scalatest.Inside
-import org.apache.pekko
-import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import pekko.http.scaladsl.unmarshalling._
-import pekko.http.scaladsl.marshalling._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import spray.json.DefaultJsonProtocol._
-import MediaTypes._
+
 import HttpCharsets._
+import MediaTypes._
 import headers._
 import org.xml.sax.SAXParseException
+import spray.json.DefaultJsonProtocol._
 
+import org.apache.pekko
+import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
+import pekko.http.scaladsl.marshalling._
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.unmarshalling._
 import pekko.testkit.EventFilter
+
+import org.scalatest.Inside
 
 class MarshallingDirectivesSpec extends RoutingSpec with Inside {
   import ScalaXmlSupport._

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
@@ -18,8 +18,6 @@ import scala.concurrent.Future
 import scala.util.{ Failure, Try }
 import scala.xml.NodeSeq
 
-import HttpCharsets._
-import MediaTypes._
 import org.xml.sax.SAXParseException
 import spray.json.DefaultJsonProtocol._
 
@@ -28,6 +26,8 @@ import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpCharsets._
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.unmarshalling._
 import pekko.testkit.EventFilter

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
@@ -20,7 +20,6 @@ import scala.xml.NodeSeq
 
 import HttpCharsets._
 import MediaTypes._
-import headers._
 import org.xml.sax.SAXParseException
 import spray.json.DefaultJsonProtocol._
 
@@ -29,6 +28,7 @@ import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.unmarshalling._
 import pekko.testkit.EventFilter
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MethodDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MethodDirectivesSpec.scala
@@ -13,13 +13,13 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpMethods, StatusCodes }
 import pekko.http.scaladsl.server._
 import pekko.stream.scaladsl.Source
-
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 class MethodDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -20,10 +20,9 @@ import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
 import scala.util.Try
 
-import headers._
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server.util.VarArgsFunction1
 import pekko.testkit._
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -20,11 +20,12 @@ import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
 import scala.util.Try
 
+import headers._
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.server.util.VarArgsFunction1
 import pekko.testkit._
-import headers._
 
 class MiscDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -14,10 +14,11 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import org.scalatest.Inside
 import org.apache.pekko
-import pekko.http.scaladsl.unmarshalling.Unmarshaller, Unmarshaller._
 import pekko.http.scaladsl.model.StatusCodes
+import pekko.http.scaladsl.unmarshalling.Unmarshaller, Unmarshaller._
+
+import org.scalatest.Inside
 import org.scalatest.freespec.AnyFreeSpec
 
 class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with Inside {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -16,9 +16,11 @@ package org.apache.pekko.http.scaladsl.server.directives
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.immutable.ListMap
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.StatusCodes
 import pekko.http.scaladsl.server._
+
 import org.scalatest.Inside
 
 class PathDirectivesSpec extends RoutingSpec with Inside {
@@ -608,8 +610,8 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
     }
   }
 
-  import pekko.http.scaladsl.model.headers.Location
   import pekko.http.scaladsl.model.Uri
+  import pekko.http.scaladsl.model.headers.Location
 
   private def checkRedirectTo(expectedUri: Uri) =
     check {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RangeDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RangeDirectivesSpec.scala
@@ -18,14 +18,16 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+
 import org.apache.pekko
-import pekko.http.scaladsl.model.StatusCodes._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.model.headers._
 import pekko.http.impl.util._
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
 import pekko.stream.scaladsl.{ Sink, Source }
-import pekko.util.ByteString
 import pekko.testkit._
+import pekko.util.ByteString
+
 import org.scalatest.{ Inside, Inspectors }
 
 class RangeDirectivesSpec extends RoutingSpec with Inspectors with Inside {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RespondWithDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RespondWithDirectivesSpec.scala
@@ -13,10 +13,10 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
-import org.apache.pekko
-import pekko.http.scaladsl.model._
 import headers._
 
+import org.apache.pekko
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.server._
 
 class RespondWithDirectivesSpec extends RoutingSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RespondWithDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RespondWithDirectivesSpec.scala
@@ -13,10 +13,9 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
-import headers._
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server._
 
 class RespondWithDirectivesSpec extends RoutingSpec {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -16,15 +16,14 @@ package org.apache.pekko.http.scaladsl.server.directives
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 
-import StatusCodes._
-import headers._
-
 import org.apache.pekko
 import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server._
 import pekko.testkit.EventFilter
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -13,19 +13,21 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
+
+import StatusCodes._
+import headers._
+
 import org.apache.pekko
 import pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport
-
-import scala.concurrent.{ Await, Future, Promise }
-import scala.concurrent.duration._
-import pekko.testkit.EventFilter
 import pekko.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import pekko.http.scaladsl.marshalling._
-import pekko.http.scaladsl.server._
 import pekko.http.scaladsl.model._
-import headers._
-import StatusCodes._
+import pekko.http.scaladsl.server._
+import pekko.testkit.EventFilter
+
 import org.scalatest.wordspec.AnyWordSpec
 
 class RouteDirectivesSpec extends AnyWordSpec with GenericRoutingSpec {
@@ -110,8 +112,8 @@ class RouteDirectivesSpec extends AnyWordSpec with GenericRoutingSpec {
                   // Needs to avoid importing more implicits accidentally from DefaultJsonProtocol to avoid ambiguity in
                   // Scala 2
                   implicit val mapFormat: spray.json.RootJsonFormat[Map[String, String]] = {
-                    import spray.json.DefaultJsonProtocol
                     import DefaultJsonProtocol._
+                    import spray.json.DefaultJsonProtocol
                     DefaultJsonProtocol.mapFormat
                   }
                   StatusCodes.BadRequest -> Map[String, String]("error" -> "User already Registered")
@@ -280,9 +282,9 @@ class RouteDirectivesSpec extends AnyWordSpec with GenericRoutingSpec {
 
   case class Data(name: String, age: Int)
   object Data {
-    import spray.json.DefaultJsonProtocol._
-    import SprayJsonSupport._
     import ScalaXmlSupport._
+    import SprayJsonSupport._
+    import spray.json.DefaultJsonProtocol._
 
     val jsonMarshaller: ToEntityMarshaller[Data] = jsonFormat2(Data.apply)
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -111,9 +111,8 @@ class RouteDirectivesSpec extends AnyWordSpec with GenericRoutingSpec {
                   // Needs to avoid importing more implicits accidentally from DefaultJsonProtocol to avoid ambiguity in
                   // Scala 2
                   implicit val mapFormat: spray.json.RootJsonFormat[Map[String, String]] = {
-                    import DefaultJsonProtocol._
-                    import spray.json.DefaultJsonProtocol
-                    DefaultJsonProtocol.mapFormat
+                    import spray.json.DefaultJsonProtocol._
+                    spray.json.DefaultJsonProtocol.mapFormat
                   }
                   StatusCodes.BadRequest -> Map[String, String]("error" -> "User already Registered")
               }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/SecurityDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/SecurityDirectivesSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
+
 import org.apache.pekko
-import pekko.http.scaladsl.testkit.RouteTestTimeout
 import pekko.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import pekko.http.scaladsl.server.RoutingSpec
+import pekko.http.scaladsl.testkit.RouteTestTimeout
 import pekko.testkit._
-
-import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
 
 class TimeoutDirectivesSpec extends RoutingSpec {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/WebSocketDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/WebSocketDirectivesSpec.scala
@@ -14,15 +14,8 @@
 package org.apache.pekko.http.scaladsl.server.directives
 
 import org.apache.pekko
-import pekko.util.ByteString
-
-import pekko.stream.OverflowStrategy
-import pekko.stream.scaladsl.{ Flow, Sink, Source }
-
-import pekko.http.scaladsl.testkit.WSProbe
-
-import pekko.http.scaladsl.model.headers.`Sec-WebSocket-Protocol`
 import pekko.http.scaladsl.model.StatusCodes
+import pekko.http.scaladsl.model.headers.`Sec-WebSocket-Protocol`
 import pekko.http.scaladsl.model.ws._
 import pekko.http.scaladsl.server.{
   ExpectedWebSocketRequestRejection,
@@ -30,6 +23,10 @@ import pekko.http.scaladsl.server.{
   RoutingSpec,
   UnsupportedWebSocketSubprotocolRejection
 }
+import pekko.http.scaladsl.testkit.WSProbe
+import pekko.stream.OverflowStrategy
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
+import pekko.util.ByteString
 
 class WebSocketDirectivesSpec extends RoutingSpec {
   "the handleWebSocketMessages directive" should {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/settings/OversizedSseStrategySpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/settings/OversizedSseStrategySpec.scala
@@ -12,6 +12,7 @@ package scaladsl
 package settings
 
 import org.apache.pekko.http.scaladsl.settings.OversizedSseStrategy
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettingsEqualitySpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettingsEqualitySpec.scala
@@ -13,9 +13,10 @@
 
 package org.apache.pekko.http.scaladsl.settings
 
-import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import com.typesafe.config.ConfigFactory
 
 class RoutingSettingsEqualitySpec extends AnyWordSpec with Matchers {
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -13,19 +13,20 @@
 
 package org.apache.pekko.http.scaladsl.unmarshalling
 
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.impl.util._
-import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.stream.scaladsl._
 import pekko.testkit._
 import pekko.util.ByteString
-import org.scalatest.matchers.Matcher
 
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import org.scalatest.matchers.Matcher
 
 trait MultipartUnmarshallersSpec extends PekkoSpecWithMaterializer {
   implicit val ec: ExecutionContext = system.dispatcher

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -16,21 +16,23 @@ package org.apache.pekko.http.scaladsl.unmarshalling
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 
-import org.apache.pekko
-import pekko.http.scaladsl.unmarshalling.Unmarshaller.EitherUnmarshallingException
-import org.scalatest.BeforeAndAfterAll
-import pekko.http.scaladsl.testkit.ScalatestUtils
-import pekko.actor.ActorSystem
-import pekko.http.scaladsl.model.MediaType.WithFixedCharset
-import pekko.http.scaladsl.model._
-import pekko.testkit._
-import com.typesafe.config.ConfigFactory
-
-import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.MediaType.WithFixedCharset
+import pekko.http.scaladsl.testkit.ScalatestUtils
+import pekko.http.scaladsl.unmarshalling.Unmarshaller.EitherUnmarshallingException
+import pekko.testkit._
+
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import com.typesafe.config.ConfigFactory
 
 class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
@@ -16,11 +16,13 @@ package scaladsl
 package unmarshalling
 package sse
 
-import org.apache.pekko
-import pekko.actor.ActorSystem
-import org.scalatest.{ BeforeAndAfterAll, Suite }
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+
+import org.scalatest.{ BeforeAndAfterAll, Suite }
 
 trait BaseUnmarshallingSpec extends BeforeAndAfterAll { this: Suite =>
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamParserOversizedSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamParserOversizedSpec.scala
@@ -17,6 +17,7 @@ import pekko.http.scaladsl.model.sse.ServerSentEvent
 import pekko.http.scaladsl.settings.OversizedSseStrategy
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.ByteString
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSimpleSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSimpleSpec.scala
@@ -12,6 +12,8 @@ package scaladsl
 package unmarshalling
 package sse
 
+import scala.concurrent.ExecutionContext
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.http.scaladsl.model.HttpEntity
@@ -19,10 +21,9 @@ import pekko.http.scaladsl.model.MediaTypes.`text/event-stream`
 import pekko.http.scaladsl.model.sse.ServerSentEvent
 import pekko.http.scaladsl.settings.{ OversizedSseStrategy, ServerSentEventSettings }
 import pekko.stream.scaladsl.{ Sink, Source }
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-
-import scala.concurrent.ExecutionContext
 
 final class EventStreamUnmarshallingSimpleSpec extends AsyncWordSpec with Matchers with BaseUnmarshallingSpec {
   implicit val ec: ExecutionContext = system.dispatcher

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSpec.scala
@@ -16,6 +16,10 @@ package scaladsl
 package unmarshalling
 package sse
 
+import java.util.{ List => JList }
+
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.http.scaladsl.model.HttpEntity
@@ -24,8 +28,6 @@ import pekko.http.scaladsl.model.sse.ServerSentEvent
 import pekko.http.scaladsl.settings.ServerSentEventSettings
 import pekko.stream.scaladsl.{ Sink, Source }
 
-import java.util.{ List => JList }
-import scala.collection.immutable.Seq
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
@@ -49,6 +51,7 @@ object EventStreamUnmarshallingSpec {
 
 final class EventStreamUnmarshallingSpec extends AsyncWordSpec with Matchers with BaseUnmarshallingSpec {
   import EventStreamUnmarshallingSpec._
+
   import pekko.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling._
 
   "A HTTP entity with media-type text/event-stream" should {

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserEdgeCasesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserEdgeCasesSpec.scala
@@ -16,6 +16,7 @@ import org.apache.pekko
 import pekko.http.scaladsl.settings.OversizedSseStrategy
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.ByteString
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserOversizedSimpleSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserOversizedSimpleSpec.scala
@@ -16,6 +16,7 @@ import org.apache.pekko
 import pekko.http.scaladsl.settings.OversizedSseStrategy
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.ByteString
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParserSpec.scala
@@ -19,6 +19,7 @@ package sse
 import org.apache.pekko
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.ByteString
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
@@ -19,6 +19,7 @@ package sse
 import org.apache.pekko
 import pekko.http.scaladsl.model.sse.ServerSentEvent
 import pekko.stream.scaladsl.{ Sink, Source }
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 

--- a/http/src/main/scala/org/apache/pekko/http/impl/settings/RoutingSettingsImpl.scala
+++ b/http/src/main/scala/org/apache/pekko/http/impl/settings/RoutingSettingsImpl.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.http.impl.settings
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.impl.util._
+
 import com.typesafe.config.Config
 
 /** INTERNAL API */

--- a/http/src/main/scala/org/apache/pekko/http/impl/settings/ServerSentEventSettingsImpl.scala
+++ b/http/src/main/scala/org/apache/pekko/http/impl/settings/ServerSentEventSettingsImpl.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.impl.util.SettingsCompanionImpl
 import pekko.http.scaladsl.settings.OversizedSseStrategy
+
 import com.typesafe.config.Config
 
 @InternalApi

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/common/PartialApplication.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/common/PartialApplication.scala
@@ -13,8 +13,9 @@
 
 package org.apache.pekko.http.javadsl.common
 
-import org.apache.pekko.annotation.ApiMayChange
 import java.util.function.{ BiFunction, Function }
+
+import org.apache.pekko.annotation.ApiMayChange
 
 /**
  * Contains helpful methods to partially apply Functions for Java

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/marshalling/Marshaller.scala
@@ -15,6 +15,9 @@ package org.apache.pekko.http.javadsl.marshalling
 
 import java.util.{ function, Optional }
 
+import scala.annotation.unchecked.uncheckedVariance
+import scala.concurrent.ExecutionContext
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.impl.util.JavaMapping
@@ -24,9 +27,6 @@ import pekko.http.scaladsl.marshalling
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model.{ FormData, HttpCharset }
 import pekko.util.ByteString
-
-import scala.concurrent.ExecutionContext
-import scala.annotation.unchecked.uncheckedVariance
 
 object Marshaller {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Directives.scala
@@ -15,12 +15,12 @@ package org.apache.pekko.http.javadsl.server
 
 import java.util.function.{ BiFunction, Function, Supplier }
 
+import scala.annotation.nowarn
+import scala.annotation.varargs
+
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
 import pekko.http.javadsl.server.directives.FramedEntityStreamingDirectives
-import scala.annotation.nowarn
-
-import scala.annotation.varargs
 
 abstract class AllDirectives extends FramedEntityStreamingDirectives
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/ExceptionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/ExceptionHandler.scala
@@ -13,12 +13,13 @@
 
 package org.apache.pekko.http.javadsl.server
 
-import org.apache.pekko
-import pekko.http.scaladsl.server
-import pekko.http.javadsl.settings.RoutingSettings
-import pekko.http.impl.util.JavaMapping.Implicits._
 import RoutingJavaMapping._
+
+import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.http.javadsl.settings.RoutingSettings
+import pekko.http.scaladsl.server
 
 object ExceptionHandler {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/PathMatchers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/PathMatchers.scala
@@ -16,13 +16,13 @@ package org.apache.pekko.http.javadsl.server
 import java.util.UUID
 import java.util.regex.Pattern
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.pekko
 import pekko.http.javadsl.common.RegexConverters.toScala
 import pekko.http.scaladsl.model.Uri.Path
 import pekko.http.scaladsl.server.{ PathMatcher => SPathMatcher }
 import pekko.http.scaladsl.server.{ PathMatchers => SPathMatchers }
-
-import scala.jdk.CollectionConverters._
 
 final class PathMatchers
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RejectionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RejectionHandler.scala
@@ -15,13 +15,13 @@ package org.apache.pekko.http.javadsl.server
 
 import java.util.function
 
+import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
+
 import org.apache.pekko
 import pekko.http.impl.util.JavaMapping
 import pekko.http.javadsl.model.HttpResponse
 import pekko.http.scaladsl.server
-
-import scala.reflect.ClassTag
-import scala.jdk.CollectionConverters._
 
 object RejectionHandler {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Rejections.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Rejections.scala
@@ -13,24 +13,24 @@
 
 package org.apache.pekko.http.javadsl.server
 
+import java.lang.{ Iterable => JIterable }
 import java.util.Optional
 import java.util.function.{ Function => JFunction }
-import java.lang.{ Iterable => JIterable }
-
-import org.apache.pekko
-import pekko.annotation.DoNotInherit
-import pekko.http.impl.util.JavaMapping
-import pekko.http.javadsl.model._
-import pekko.http.javadsl.model.headers.{ ByteRange, HttpChallenge, HttpEncoding }
-import pekko.http.scaladsl
-import pekko.http.scaladsl.server.ContentNegotiator.Alternative
-import pekko.http.scaladsl.server._
-import pekko.http.impl.util.Util
-import pekko.pattern.CircuitBreakerOpenException
 
 import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
+
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
+import pekko.http.impl.util.JavaMapping
+import pekko.http.impl.util.Util
+import pekko.http.javadsl.model._
+import pekko.http.javadsl.model.headers.{ ByteRange, HttpChallenge, HttpEncoding }
+import pekko.http.scaladsl
+import pekko.http.scaladsl.server._
+import pekko.http.scaladsl.server.ContentNegotiator.Alternative
+import pekko.pattern.CircuitBreakerOpenException
 
 /**
  * A rejection encapsulates a specific reason why a Route was not able to handle a request. Rejections are gathered
@@ -359,9 +359,10 @@ trait RejectionError extends RuntimeException {
 }
 
 object Rejections {
-  import pekko.http.scaladsl.{ server => s }
   import JavaMapping.Implicits._
   import RoutingJavaMapping._
+
+  import pekko.http.scaladsl.{ server => s }
 
   def method(supported: HttpMethod): MethodRejection =
     s.MethodRejection(JavaMapping.toScala(supported))

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RequestContext.scala
@@ -16,6 +16,10 @@ package org.apache.pekko.http.javadsl.server
 import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 
+import scala.annotation.varargs
+import scala.concurrent.ExecutionContextExecutor
+import scala.jdk.FutureConverters._
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
@@ -26,17 +30,13 @@ import pekko.http.javadsl.model.HttpResponse
 import pekko.http.javadsl.model.StatusCode
 import pekko.http.javadsl.model.Uri
 import pekko.http.javadsl.model.headers.Location
-import pekko.http.javadsl.settings.RoutingSettings
 import pekko.http.javadsl.settings.ParserSettings
+import pekko.http.javadsl.settings.RoutingSettings
 import pekko.http.scaladsl
 import pekko.http.scaladsl.marshalling.ToResponseMarshallable
 import pekko.http.scaladsl.model.Uri.Path
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.stream.Materializer
-
-import scala.annotation.varargs
-import scala.concurrent.ExecutionContextExecutor
-import scala.jdk.FutureConverters._
 
 class RequestContext private (val delegate: scaladsl.server.RequestContext) {
   import RequestContext._

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/Route.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/Route.scala
@@ -25,10 +25,10 @@ import pekko.http.javadsl.model.HttpRequest
 import pekko.http.javadsl.model.HttpResponse
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server
+import pekko.japi.function.Function
 import pekko.stream.Materializer
 import pekko.stream.SystemMaterializer
 import pekko.stream.javadsl.Flow
-import pekko.japi.function.Function
 
 /**
  * In the Java DSL, a Route can only consist of combinations of the built-in directives. A Route can not be

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RouteResult.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RouteResult.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.javadsl.server
 
 import org.apache.pekko
+import pekko.http.impl.util.{ JavaMapping, Util }
 import pekko.http.javadsl.model.HttpResponse
 
 trait RouteResult {}
@@ -28,9 +29,8 @@ trait Rejected extends RouteResult {
 
 object RouteResults {
   import JavaMapping.Implicits._
-  import RoutingJavaMapping._
 
-  import pekko.http.impl.util.{ JavaMapping, Util }
+  import pekko.http.javadsl.server.RoutingJavaMapping._
   import pekko.http.scaladsl.{ server => s }
 
   def complete(response: HttpResponse): Complete = {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RouteResult.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RouteResult.scala
@@ -27,10 +27,11 @@ trait Rejected extends RouteResult {
 }
 
 object RouteResults {
-  import pekko.http.scaladsl.{ server => s }
-  import pekko.http.impl.util.{ JavaMapping, Util }
   import JavaMapping.Implicits._
   import RoutingJavaMapping._
+
+  import pekko.http.impl.util.{ JavaMapping, Util }
+  import pekko.http.scaladsl.{ server => s }
 
   def complete(response: HttpResponse): Complete = {
     s.RouteResult.Complete(JavaMapping.toScala(response))

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/RoutingJavaMapping.scala
@@ -15,17 +15,17 @@ package org.apache.pekko.http.javadsl.server
 
 import java.util.concurrent.CompletionStage
 
+import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.http.impl.util.JavaMapping._
-import pekko.http.impl.util._
-import pekko.http.javadsl.common.EntityStreamingSupport
 import pekko.http.{ javadsl, scaladsl }
-import pekko.http.scaladsl.server.{ directives => sdirectives }
-import pekko.http.scaladsl.{ common => scommon }
+import pekko.http.impl.util._
+import pekko.http.impl.util.JavaMapping._
+import pekko.http.javadsl.common.EntityStreamingSupport
 import pekko.http.javadsl.server.{ directives => jdirectives }
-
-import scala.collection.immutable
+import pekko.http.scaladsl.{ common => scommon }
+import pekko.http.scaladsl.server.{ directives => sdirectives }
 
 /**
  * INTERNAL API

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/AttributeDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/AttributeDirectives.scala
@@ -15,12 +15,12 @@ package org.apache.pekko.http.javadsl.server.directives
 
 import java.util.{ function => jf, Optional }
 
+import scala.jdk.OptionConverters._
+
 import org.apache.pekko
 import pekko.http.javadsl.model.AttributeKey
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.directives.{ AttributeDirectives => D }
-
-import scala.jdk.OptionConverters._
 
 abstract class AttributeDirectives extends HeaderDirectives {
   import pekko.http.impl.util.JavaMapping._

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/BasicDirectives.scala
@@ -13,14 +13,22 @@
 
 package org.apache.pekko.http.javadsl.server.directives
 
+import java.lang.{ Iterable => JIterable }
+import java.time.{ Duration => JDuration }
+import java.util.{ List => JList }
+import java.util.concurrent.CompletionStage
+import java.util.function.{ Function => JFunction }
+import java.util.function.Predicate
+import java.util.function.Supplier
+
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.DurationConverters._
+import scala.jdk.FutureConverters._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.LoggingAdapter
-import pekko.japi.Util
-import pekko.stream.Materializer
-import pekko.stream.javadsl.Source
-import pekko.util.ByteString
-
 import pekko.http.impl.model.JavaUri
 import pekko.http.impl.util.JavaMapping
 import pekko.http.impl.util.Util.convertIterable
@@ -39,23 +47,15 @@ import pekko.http.javadsl.settings.{ ParserSettings, RoutingSettings }
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server.{ Directives => D }
 import pekko.http.scaladsl.util.FastFuture._
-
-import java.lang.{ Iterable => JIterable }
-import java.time.{ Duration => JDuration }
-import java.util.{ List => JList }
-import java.util.concurrent.CompletionStage
-import java.util.function.{ Function => JFunction }
-import java.util.function.Predicate
-import java.util.function.Supplier
-
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
-import scala.concurrent.duration.FiniteDuration
-import scala.jdk.DurationConverters._
-import scala.jdk.FutureConverters._
+import pekko.japi.Util
+import pekko.stream.Materializer
+import pekko.stream.javadsl.Source
+import pekko.util.ByteString
 
 abstract class BasicDirectives {
-  import pekko.http.impl.util.JavaMapping.Implicits._
   import RoutingJavaMapping._
+
+  import pekko.http.impl.util.JavaMapping.Implicits._
 
   def mapRequest(f: JFunction[HttpRequest, HttpRequest], inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRequest(rq => f.apply(rq.asJava).asScala) { inner.get.delegate }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/DebuggingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/DebuggingDirectives.scala
@@ -13,8 +13,10 @@
 
 package org.apache.pekko.http.javadsl.server.directives
 
-import java.util.function.{ BiFunction, Function => JFunction, Supplier }
 import java.util.{ List => JList, Optional }
+import java.util.function.{ BiFunction, Function => JFunction, Supplier }
+
+import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
 import pekko.event.Logging
@@ -22,14 +24,13 @@ import pekko.event.Logging.LogLevel
 import pekko.http.javadsl.model.{ HttpRequest, HttpResponse }
 import pekko.http.javadsl.server.{ Rejection, Route, RoutingJavaMapping }
 import pekko.http.scaladsl
-import pekko.http.scaladsl.server.directives.LoggingMagnet
 import pekko.http.scaladsl.server.{ Directives => D, RouteResult }
-
-import scala.jdk.CollectionConverters._
+import pekko.http.scaladsl.server.directives.LoggingMagnet
 
 abstract class DebuggingDirectives extends CookieDirectives {
-  import pekko.http.impl.util.JavaMapping.Implicits._
   import RoutingJavaMapping._
+
+  import pekko.http.impl.util.JavaMapping.Implicits._
 
   /**
    * Produces a log entry for every incoming request.

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FileAndResourceDirectives.scala
@@ -15,15 +15,15 @@ package org.apache.pekko.http.javadsl.server.directives
 
 import java.io.File
 
+import scala.annotation.varargs
+import scala.jdk.CollectionConverters._
+
 import org.apache.pekko
 import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.ContentType
 import pekko.http.javadsl.model.RequestEntity
 import pekko.http.javadsl.server.{ Route, RoutingJavaMapping }
 import pekko.http.scaladsl.server.{ Directives => D }
-
-import scala.annotation.varargs
-import scala.jdk.CollectionConverters._
 
 abstract class DirectoryListing {
   def getPath: String
@@ -42,8 +42,9 @@ trait DirectoryRenderer {
  * the pekko.actor.ActorSystem class.
  */
 abstract class FileAndResourceDirectives extends ExecutionDirectives {
-  import pekko.http.impl.util.JavaMapping.Implicits._
   import RoutingJavaMapping._
+
+  import pekko.http.impl.util.JavaMapping.Implicits._
 
   /**
    * Completes GET requests with the content of the given resource loaded from the default ClassLoader,

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FileUploadDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FileUploadDirectives.scala
@@ -20,7 +20,6 @@ import java.util.function.{ BiFunction, Function => JFunction }
 
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
-
 import pekko.http.javadsl.model.ContentType
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.{ Directives => D }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FormFieldDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FormFieldDirectives.scala
@@ -18,14 +18,14 @@ import java.util.AbstractMap.SimpleImmutableEntry
 import java.util.Optional
 import java.util.function.{ Function => JFunction }
 
-import org.apache.pekko
-import pekko.http.javadsl.unmarshalling.Unmarshaller
-import pekko.http.javadsl.server.Route
-import pekko.http.scaladsl.server.{ Directives => D }
-import pekko.http.scaladsl.server.directives.ParameterDirectives._
-
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
+
+import org.apache.pekko
+import pekko.http.javadsl.server.Route
+import pekko.http.javadsl.unmarshalling.Unmarshaller
+import pekko.http.scaladsl.server.{ Directives => D }
+import pekko.http.scaladsl.server.directives.ParameterDirectives._
 
 abstract class FormFieldDirectives extends FileUploadDirectives {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -20,8 +20,8 @@ import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.{ HttpEntity, _ }
 import pekko.http.javadsl.server.Route
 import pekko.http.javadsl.unmarshalling.Unmarshaller
-import pekko.http.scaladsl.marshalling.ToResponseMarshaller
 import pekko.http.scaladsl.marshalling.ToResponseMarshallable
+import pekko.http.scaladsl.marshalling.ToResponseMarshaller
 import pekko.http.scaladsl.server.{ Directives => D }
 import pekko.stream.javadsl.Source
 import pekko.util.ByteString
@@ -29,8 +29,8 @@ import pekko.util.ByteString
 /** EXPERIMENTAL API */
 abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
 
-  import pekko.http.javadsl.server.RoutingJavaMapping.Implicits._
   import pekko.http.javadsl.server.RoutingJavaMapping._
+  import pekko.http.javadsl.server.RoutingJavaMapping.Implicits._
 
   @CorrespondsTo("asSourceOf")
   def entityAsSourceOf[T](um: Unmarshaller[ByteString, T], support: EntityStreamingSupport,

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/FutureDirectives.scala
@@ -18,16 +18,16 @@ import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 import java.util.function.Supplier
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.FutureConverters._
+import scala.util.Try
+
 import org.apache.pekko
 import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.RequestEntity
 import pekko.http.javadsl.server.Route
 import pekko.http.scaladsl.server.directives.{ CompleteOrRecoverWithMagnet, FutureDirectives => D }
 import pekko.pattern.CircuitBreaker
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.jdk.FutureConverters._
-import scala.util.Try
 
 abstract class FutureDirectives extends FormFieldDirectives {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/HeaderDirectives.scala
@@ -13,20 +13,20 @@
 
 package org.apache.pekko.http.javadsl.server.directives
 
-import java.util.Optional
 import java.util.{ function => jf }
-
-import org.apache.pekko
-import pekko.actor.ReflectiveDynamicAccess
-import pekko.http.javadsl.model.headers.{ HttpOriginRange, HttpOriginRanges }
-import pekko.http.javadsl.model.HttpHeader
-import pekko.http.javadsl.server.Route
-import pekko.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion }
-import pekko.http.scaladsl.server.directives.{ HeaderDirectives => D, HeaderMagnet }
+import java.util.Optional
 
 import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
+
+import org.apache.pekko
+import pekko.actor.ReflectiveDynamicAccess
+import pekko.http.javadsl.model.HttpHeader
+import pekko.http.javadsl.model.headers.{ HttpOriginRange, HttpOriginRanges }
+import pekko.http.javadsl.server.Route
+import pekko.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion }
+import pekko.http.scaladsl.server.directives.{ HeaderDirectives => D, HeaderMagnet }
 
 abstract class HeaderDirectives extends FutureDirectives {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MethodDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MethodDirectives.scala
@@ -16,9 +16,9 @@ package org.apache.pekko.http.javadsl.server.directives
 import java.util.function
 
 import org.apache.pekko
+import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model.HttpMethod
 import pekko.http.javadsl.server.Route
-import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.scaladsl.server.directives.{ MethodDirectives => D }
 
 abstract class MethodDirectives extends MarshallingDirectives {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MiscDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/MiscDirectives.scala
@@ -15,17 +15,16 @@ package org.apache.pekko.http.javadsl.server
 package directives
 
 import java.lang.{ Iterable => JIterable }
-import java.util.function.BooleanSupplier
 import java.util.function.{ Function => JFunction }
+import java.util.function.BooleanSupplier
 import java.util.function.Supplier
 
 import scala.jdk.CollectionConverters._
 
 import org.apache.pekko
+import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model.RemoteAddress
 import pekko.http.javadsl.model.headers.Language
-import pekko.http.impl.util.JavaMapping.Implicits._
-
 import pekko.http.scaladsl.server.{ Directives => D }
 
 abstract class MiscDirectives extends MethodDirectives {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/ParameterDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/ParameterDirectives.scala
@@ -13,18 +13,18 @@
 
 package org.apache.pekko.http.javadsl.server.directives
 
+import java.util.{ List => JList, Map => JMap, Optional }
 import java.util.AbstractMap.SimpleImmutableEntry
 import java.util.function.{ Function => JFunction }
-import java.util.{ List => JList, Map => JMap, Optional }
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
 
 import org.apache.pekko
 import pekko.http.javadsl.server.Route
 import pekko.http.javadsl.unmarshalling.Unmarshaller
-import pekko.http.scaladsl.server.directives.ParameterDirectives._
 import pekko.http.scaladsl.server.directives.{ ParameterDirectives => D }
-
-import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters._
+import pekko.http.scaladsl.server.directives.ParameterDirectives._
 
 abstract class ParameterDirectives extends MiscDirectives {
 

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/PathDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/PathDirectives.scala
@@ -13,24 +13,22 @@
 
 package org.apache.pekko.http.javadsl.server.directives
 
-import java.util.function.BiFunction
 import java.util.function.{ Function => JFunction }
+import java.util.function.BiFunction
 import java.util.function.Supplier
-
-import org.apache.pekko
-import pekko.http.javadsl.unmarshalling.Unmarshaller
 
 import scala.util.Failure
 import scala.util.Success
 
+import org.apache.pekko
 import pekko.http.javadsl.model.StatusCode
 import pekko.http.javadsl.server.PathMatcher0
 import pekko.http.javadsl.server.PathMatcher1
 import pekko.http.javadsl.server.PathMatcher2
 import pekko.http.javadsl.server.Route
+import pekko.http.javadsl.unmarshalling.Unmarshaller
 import pekko.http.scaladsl.model.StatusCodes.Redirection
 import pekko.http.scaladsl.server.{ Directives => D }
-
 import pekko.http.scaladsl.server.PathMatchers
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RangeDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RangeDirectives.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.javadsl.server
 package directives
 
 import java.util.function.Supplier
+
 import org.apache.pekko.http.scaladsl.server.{ Directives => D }
 
 abstract class RangeDirectives extends PathDirectives {

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteAdapter.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/RouteAdapter.scala
@@ -15,21 +15,21 @@ package org.apache.pekko.http.javadsl.server.directives
 
 import java.util.concurrent.CompletionStage
 
+import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.{ ActorSystem, ClassicActorSystemProvider }
 import pekko.annotation.InternalApi
+import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.model.HttpRequest
 import pekko.http.javadsl.model.HttpResponse
-import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl.server.{ ExceptionHandler, RejectionHandler, Route }
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server.RouteConcatenation._
 import pekko.japi.function.Function
 import pekko.stream.{ javadsl, Materializer }
 import pekko.stream.scaladsl.Flow
-
-import scala.concurrent.Future
 
 /** INTERNAL API */
 @InternalApi

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/SecurityDirectives.scala
@@ -18,16 +18,16 @@ import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 import java.util.function.Supplier
 
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.jdk.FutureConverters._
+import scala.jdk.OptionConverters._
+
 import org.apache.pekko
 import pekko.http.javadsl.model.headers.HttpChallenge
 import pekko.http.javadsl.model.headers.HttpCredentials
 import pekko.http.javadsl.server.{ RequestContext, Route }
 import pekko.http.scaladsl
 import pekko.http.scaladsl.server.{ Directives => D }
-
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-import scala.jdk.FutureConverters._
-import scala.jdk.OptionConverters._
 
 object SecurityDirectives {
 
@@ -58,6 +58,7 @@ object SecurityDirectives {
 
 abstract class SecurityDirectives extends SchemeDirectives {
   import SecurityDirectives._
+
   import pekko.http.impl.util.JavaMapping.Implicits._
 
   /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/WebSocketDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/server/directives/WebSocketDirectives.scala
@@ -20,9 +20,9 @@ import java.util.function.{ Function => JFunction }
 
 import org.apache.pekko
 import pekko.NotUsed
-import pekko.http.scaladsl.model.{ ws => s }
 import pekko.http.javadsl.model.ws.Message
 import pekko.http.javadsl.model.ws.WebSocketUpgrade
+import pekko.http.scaladsl.model.{ ws => s }
 import pekko.http.scaladsl.server.{ Directives => D }
 import pekko.stream.javadsl.Flow
 import pekko.stream.scaladsl

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.annotation.DoNotInherit
 import pekko.http.impl.settings.RoutingSettingsImpl
+
 import com.typesafe.config.Config
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSentEventSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSentEventSettings.scala
@@ -18,6 +18,7 @@ import pekko.actor.ActorSystem
 import pekko.annotation.{ ApiMayChange, DoNotInherit }
 import pekko.http.impl.settings.ServerSentEventSettingsImpl
 import pekko.http.scaladsl.settings.{ OversizedSseStrategy => ScalaOversizedSseStrategy }
+
 import com.typesafe.config.Config
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -24,10 +24,10 @@ import scala.jdk.FutureConverters._
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
+import pekko.http.{ javadsl => jm }
 import pekko.http.impl.model.JavaQuery
 import pekko.http.impl.util.JavaMapping
 import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.http.{ javadsl => jm }
 import pekko.http.javadsl.model._
 import pekko.http.scaladsl.model.{ ContentTypeRange, ContentTypes }
 import pekko.http.scaladsl.unmarshalling

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -13,17 +13,23 @@
 
 package org.apache.pekko.http.javadsl.unmarshalling
 
-import java.util.concurrent.CompletionStage
 import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import scala.annotation.nowarn
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import jm.model._
 
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
+import pekko.http.{ javadsl => jm }
 import pekko.http.impl.model.JavaQuery
 import pekko.http.impl.util.JavaMapping
 import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.http.{ javadsl => jm }
-import jm.model._
 import pekko.http.scaladsl.model.{ ContentTypeRange, ContentTypes }
 import pekko.http.scaladsl.unmarshalling
 import pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
@@ -31,11 +37,6 @@ import pekko.http.scaladsl.unmarshalling.Unmarshaller.EnhancedFromEntityUnmarsha
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.util.ByteString
-
-import scala.annotation.nowarn
-import scala.concurrent.ExecutionContext
-import scala.jdk.CollectionConverters._
-import scala.jdk.FutureConverters._
 
 object Unmarshaller extends pekko.http.javadsl.unmarshalling.Unmarshallers {
   implicit def fromScala[A, B](scalaUnmarshaller: unmarshalling.Unmarshaller[A, B]): Unmarshaller[A, B] =

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -21,15 +21,14 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
 
-import jm.model._
-
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
-import pekko.http.{ javadsl => jm }
 import pekko.http.impl.model.JavaQuery
 import pekko.http.impl.util.JavaMapping
 import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.http.{ javadsl => jm }
+import pekko.http.javadsl.model._
 import pekko.http.scaladsl.model.{ ContentTypeRange, ContentTypes }
 import pekko.http.scaladsl.unmarshalling
 import pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
@@ -39,6 +38,7 @@ import pekko.stream.{ Materializer, SystemMaterializer }
 import pekko.util.ByteString
 
 object Unmarshaller extends pekko.http.javadsl.unmarshalling.Unmarshallers {
+
   implicit def fromScala[A, B](scalaUnmarshaller: unmarshalling.Unmarshaller[A, B]): Unmarshaller[A, B] =
     scalaUnmarshaller
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/client/RequestBuilding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/client/RequestBuilding.scala
@@ -18,13 +18,12 @@ import scala.concurrent.{ Await, ExecutionContext }
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
-import HttpMethods._
-import headers.HttpCredentials
-
 import org.apache.pekko
 import pekko.event.{ Logging, LoggingAdapter }
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.model.headers.HttpCredentials
 import pekko.util.Timeout
 
 trait RequestBuilding extends TransformerPipelineSupport {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/client/RequestBuilding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/client/RequestBuilding.scala
@@ -17,13 +17,15 @@ import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext }
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
+
+import HttpMethods._
+import headers.HttpCredentials
+
 import org.apache.pekko
-import pekko.util.Timeout
 import pekko.event.{ Logging, LoggingAdapter }
 import pekko.http.scaladsl.marshalling._
 import pekko.http.scaladsl.model._
-import headers.HttpCredentials
-import HttpMethods._
+import pekko.util.Timeout
 
 trait RequestBuilding extends TransformerPipelineSupport {
   type RequestTransformer = HttpRequest => HttpRequest

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/client/TransformerPipelineSupport.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/client/TransformerPipelineSupport.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.client
 
 import scala.concurrent.{ ExecutionContext, Future }
+
 import org.apache.pekko.event.{ Logging, LoggingAdapter }
 
 trait TransformerPipelineSupport {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Coders.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Coders.scala
@@ -13,11 +13,11 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
+import scala.annotation.nowarn
+import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.http.scaladsl.model.HttpMessage
-import scala.annotation.nowarn
-
-import scala.collection.immutable
 
 @nowarn("msg=in package coding is deprecated")
 object Coders {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DataMapper.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DataMapper.scala
@@ -15,8 +15,8 @@ package org.apache.pekko.http.scaladsl.coding
 
 import org.apache.pekko
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse, RequestEntity, ResponseEntity }
-import pekko.util.ByteString
 import pekko.stream.scaladsl.Flow
+import pekko.util.ByteString
 
 /** An abstraction to transform data bytes of HttpMessages or HttpEntities */
 sealed trait DataMapper[T] {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Decoder.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Decoder.scala
@@ -13,17 +13,18 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
+import scala.concurrent.Future
+
+import headers.HttpEncoding
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model._
 import pekko.stream.{ FlowShape, Materializer }
+import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.stage.GraphStage
 import pekko.util.ByteString
-import headers.HttpEncoding
-import pekko.stream.scaladsl.{ Flow, Sink, Source }
-
-import scala.concurrent.Future
 
 trait Decoder {
   def encoding: HttpEncoding

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Decoder.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Decoder.scala
@@ -15,12 +15,11 @@ package org.apache.pekko.http.scaladsl.coding
 
 import scala.concurrent.Future
 
-import headers.HttpEncoding
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.HttpEncoding
 import pekko.stream.{ FlowShape, Materializer }
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.stage.GraphStage

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/DeflateCompressor.scala
@@ -15,14 +15,14 @@ package org.apache.pekko.http.scaladsl.coding
 
 import java.util.zip.{ Deflater, Inflater }
 
+import scala.annotation.tailrec
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.Attributes
 import pekko.stream.impl.io.ByteStringParser
 import pekko.stream.impl.io.ByteStringParser.{ ParseResult, ParseStep }
 import pekko.util.{ ByteString, ByteStringBuilder }
-
-import scala.annotation.tailrec
 
 /** Internal API */
 @InternalApi

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Encoder.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Encoder.scala
@@ -15,16 +15,17 @@ package org.apache.pekko.http.scaladsl.coding
 
 import scala.concurrent.Future
 
+import headers._
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
-import pekko.http.scaladsl.model._
 import pekko.http.impl.util.StreamUtils
+import pekko.http.scaladsl.model._
 import pekko.stream.{ FlowShape, Materializer }
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.stage.GraphStage
 import pekko.util.ByteString
-import headers._
 
 trait Encoder {
   def encoding: HttpEncoding

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Encoder.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/Encoder.scala
@@ -15,13 +15,12 @@ package org.apache.pekko.http.scaladsl.coding
 
 import scala.concurrent.Future
 
-import headers._
-
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.http.impl.util.StreamUtils
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.stream.{ FlowShape, Materializer }
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.stream.stage.GraphStage

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
@@ -13,12 +13,11 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
-import headers.HttpEncodings
-
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.impl.util.StreamUtils
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.HttpEncodings
 import pekko.stream.FlowShape
 import pekko.stream.stage.GraphStage
 import pekko.util.ByteString

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/coding/NoCoding.scala
@@ -13,14 +13,15 @@
 
 package org.apache.pekko.http.scaladsl.coding
 
+import headers.HttpEncodings
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
-import pekko.http.scaladsl.model._
 import pekko.http.impl.util.StreamUtils
+import pekko.http.scaladsl.model._
 import pekko.stream.FlowShape
 import pekko.stream.stage.GraphStage
 import pekko.util.ByteString
-import headers.HttpEncodings
 
 /**
  * An encoder and decoder for the HTTP 'identity' encoding.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/common/StrictForm.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/common/StrictForm.scala
@@ -18,13 +18,12 @@ import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 
-import FastFuture._
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.unmarshalling._
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.util.FastFuture
+import pekko.http.scaladsl.util.FastFuture._
 import pekko.stream.Materializer
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/common/StrictForm.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/common/StrictForm.scala
@@ -17,13 +17,15 @@ import scala.annotation.implicitNotFound
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
-import org.apache.pekko
-import pekko.stream.Materializer
-import pekko.http.scaladsl.unmarshalling._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.util.FastFuture
+
 import FastFuture._
+
+import org.apache.pekko
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.unmarshalling._
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import pekko.http.scaladsl.util.FastFuture
+import pekko.stream.Materializer
 
 /**
  * Read-only abstraction on top of `application/x-www-form-urlencoded` and multipart form data,

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/ContentTypeOverrider.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/ContentTypeOverrider.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.collection.immutable
+
 import org.apache.pekko.http.scaladsl.model._
 
 sealed trait ContentTypeOverrider[T] {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/EmptyValue.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/EmptyValue.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.collection.immutable
+
 import org.apache.pekko.http.scaladsl.model._
 
 class EmptyValue[+T] private (val emptyValue: T)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/GenericMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/GenericMarshallers.scala
@@ -16,9 +16,8 @@ package org.apache.pekko.http.scaladsl.marshalling
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
 
-import FastFuture._
-
 import org.apache.pekko.http.scaladsl.util.FastFuture
+import pekko.http.scaladsl.util.FastFuture._
 
 trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/GenericMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/GenericMarshallers.scala
@@ -15,8 +15,10 @@ package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
-import org.apache.pekko.http.scaladsl.util.FastFuture
+
 import FastFuture._
+
+import org.apache.pekko.http.scaladsl.util.FastFuture
 
 trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/GenericMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/GenericMarshallers.scala
@@ -16,7 +16,8 @@ package org.apache.pekko.http.scaladsl.marshalling
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
 
-import org.apache.pekko.http.scaladsl.util.FastFuture
+import org.apache.pekko
+import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
 
 trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshal.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshal.scala
@@ -14,12 +14,12 @@
 package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.concurrent.{ ExecutionContext, Future }
-import org.apache.pekko
-import pekko.http.scaladsl.server.ContentNegotiator
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.util.FastFuture._
-
 import scala.util.control.NoStackTrace
+
+import org.apache.pekko
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.server.ContentNegotiator
+import pekko.http.scaladsl.util.FastFuture._
 
 object Marshal {
   def apply[T](value: T): Marshal[T] = new Marshal(value)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/Marshaller.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.util.FastFuture

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
@@ -16,9 +16,9 @@ package org.apache.pekko.http.scaladsl.marshalling
 import java.nio.CharBuffer
 
 import org.apache.pekko
-import pekko.http.scaladsl.model.MediaTypes._
-import pekko.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
+import pekko.http.scaladsl.model.MediaTypes._
 import pekko.util.ByteString
 
 trait PredefinedToEntityMarshallers extends MultipartMarshallers {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.util.FastFuture._

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.http.scaladsl.marshalling
 
+import scala.collection.immutable
+import scala.reflect.ClassTag
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.common.EntityStreamingSupport
@@ -20,12 +23,9 @@ import pekko.http.scaladsl.marshalling.Marshal.selectMarshallingForContentType
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
-import pekko.util.ConstantFun
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
-
-import scala.collection.immutable
-import scala.reflect.ClassTag
+import pekko.util.ConstantFun
 
 trait PredefinedToResponseMarshallers extends LowPriorityToResponseMarshallerImplicits {
   import PredefinedToResponseMarshallers._

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/ToResponseMarshallable.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/ToResponseMarshallable.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl.marshalling
 
 import scala.concurrent.{ ExecutionContext, Future }
+
 import org.apache.pekko.http.scaladsl.model._
 
 /** Something that can later be marshalled into a response */

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/package.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/marshalling/package.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.scaladsl
 
 import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.util.ByteString

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ContentNegotiation.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ContentNegotiation.scala
@@ -13,11 +13,10 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import HttpCharsets.`UTF-8`
-
 import org.apache.pekko
 import pekko.http.scaladsl.model
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpCharsets.`UTF-8`
 import pekko.http.scaladsl.model.headers._
 
 final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ContentNegotiation.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ContentNegotiation.scala
@@ -13,11 +13,12 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import HttpCharsets.`UTF-8`
+
 import org.apache.pekko
 import pekko.http.scaladsl.model
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
-import HttpCharsets.`UTF-8`
 
 final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Directive.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Directive.scala
@@ -15,13 +15,14 @@ package org.apache.pekko.http.scaladsl.server
 
 import scala.collection.immutable
 import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.http.impl.util._
 import pekko.http.scaladsl.server.directives.RouteDirectives
 import pekko.http.scaladsl.server.util._
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
-import pekko.http.impl.util._
 
 /**
  * A directive that provides a tuple of values of type `L` to create an inner route.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ExceptionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ExceptionHandler.scala
@@ -13,12 +13,14 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import scala.util.control.NonFatal
-import org.apache.pekko
-import pekko.http.scaladsl.settings.RoutingSettings
-import pekko.http.scaladsl.model._
-import StatusCodes._
 import scala.language.implicitConversions
+import scala.util.control.NonFatal
+
+import StatusCodes._
+
+import org.apache.pekko
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.settings.RoutingSettings
 
 trait ExceptionHandler extends ExceptionHandler.PF {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ExceptionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/ExceptionHandler.scala
@@ -16,10 +16,9 @@ package org.apache.pekko.http.scaladsl.server
 import scala.language.implicitConversions
 import scala.util.control.NonFatal
 
-import StatusCodes._
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.settings.RoutingSettings
 
 trait ExceptionHandler extends ExceptionHandler.PF {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/HttpApp.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/HttpApp.scala
@@ -15,6 +15,11 @@ package org.apache.pekko.http.scaladsl.server
 
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.concurrent.{ blocking, Await, ExecutionContext, ExecutionContextExecutor, Future, Promise }
+import scala.concurrent.duration.Duration
+import scala.io.StdIn
+import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.ActorSystem
@@ -22,12 +27,8 @@ import pekko.event.Logging
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.Http.ServerBinding
 import pekko.http.scaladsl.settings.ServerSettings
-import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ blocking, Await, ExecutionContext, ExecutionContextExecutor, Future, Promise }
-import scala.io.StdIn
-import scala.util.{ Failure, Success, Try }
+import com.typesafe.config.ConfigFactory
 
 /**
  * DEPRECATED, consider https://github.com/apache/pekko-http-quickstart-scala.g8 instead

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/PathMatcher.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/PathMatcher.scala
@@ -14,14 +14,16 @@
 package org.apache.pekko.http.scaladsl.server
 
 import java.util.UUID
-import scala.util.matching.Regex
+
 import scala.annotation.tailrec
+import scala.util.matching.Regex
+
 import org.apache.pekko
-import pekko.http.scaladsl.server.util.Tuple
-import pekko.http.scaladsl.server.util.TupleOps._
+import pekko.http.impl.util._
 import pekko.http.scaladsl.common.NameOptionReceptacle
 import pekko.http.scaladsl.model.Uri.Path
-import pekko.http.impl.util._
+import pekko.http.scaladsl.server.util.Tuple
+import pekko.http.scaladsl.server.util.TupleOps._
 
 /**
  * A PathMatcher tries to match a prefix of a given string and returns either a PathMatcher.Matched instance

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Rejection.scala
@@ -17,21 +17,21 @@ import java.lang.Iterable
 import java.util.Optional
 import java.util.function.Function
 
-import org.apache.pekko
-import pekko.http.impl.util.Util
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.model.headers.{ ByteRange, HttpChallenge, HttpEncoding }
-import pekko.http.javadsl.{ model, server => jserver }
-import pekko.http.impl.util.JavaMapping._
-import pekko.http.impl.util.JavaMapping.Implicits._
-import pekko.pattern.CircuitBreakerOpenException
-import pekko.http.javadsl.model.headers.{ HttpOrigin => JHttpOrigin }
-import pekko.http.scaladsl.model.headers.{ HttpOrigin => SHttpOrigin }
-
 import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 import scala.runtime.AbstractFunction1
+
+import org.apache.pekko
+import pekko.http.impl.util.JavaMapping._
+import pekko.http.impl.util.JavaMapping.Implicits._
+import pekko.http.impl.util.Util
+import pekko.http.javadsl.{ model, server => jserver }
+import pekko.http.javadsl.model.headers.{ HttpOrigin => JHttpOrigin }
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.{ ByteRange, HttpChallenge, HttpEncoding }
+import pekko.http.scaladsl.model.headers.{ HttpOrigin => SHttpOrigin }
+import pekko.pattern.CircuitBreakerOpenException
 
 /**
  * A rejection encapsulates a specific reason why a Route was not able to handle a request. Rejections are gathered

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RejectionHandler.scala
@@ -13,17 +13,17 @@
 
 package org.apache.pekko.http.scaladsl.server
 
-import org.apache.pekko
-import pekko.http.scaladsl.marshalling.ToResponseMarshallable
-import pekko.http.scaladsl.model.StatusCodes._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.model.headers._
-import pekko.http.scaladsl.server.AuthenticationFailedRejection._
-import pekko.http.scaladsl.server.directives.BasicDirectives
-
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.reflect.ClassTag
+
+import org.apache.pekko
+import pekko.http.scaladsl.marshalling.ToResponseMarshallable
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.server.AuthenticationFailedRejection._
+import pekko.http.scaladsl.server.directives.BasicDirectives
 
 trait RejectionHandler extends (immutable.Seq[Rejection] => Option[Route]) { self =>
   import RejectionHandler._

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RequestContext.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RequestContext.scala
@@ -13,16 +13,16 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
-
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-import pekko.stream.Materializer
 import pekko.event.LoggingAdapter
 import pekko.http.scaladsl.marshalling.ToResponseMarshallable
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
+import pekko.stream.Materializer
 
 /**
  * This class is not meant to be extended by user code.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RequestContextImpl.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RequestContextImpl.scala
@@ -13,18 +13,18 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.event.LoggingAdapter
 import pekko.http.scaladsl.marshalling.{ Marshal, ToResponseMarshallable }
-import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.stream.Materializer
-
-import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 /**
  * INTERNAL API

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Route.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/Route.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ClassicActorSystemProvider
@@ -20,10 +22,8 @@ import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import pekko.http.scaladsl.server.directives.BasicDirectives
 import pekko.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import pekko.http.scaladsl.util.FastFuture._
-import pekko.stream.scaladsl.Flow
 import pekko.stream.{ Materializer, SystemMaterializer }
-
-import scala.concurrent.{ ExecutionContextExecutor, Future }
+import pekko.stream.scaladsl.Flow
 
 object Route {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RouteResult.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RouteResult.scala
@@ -13,16 +13,16 @@
 
 package org.apache.pekko.http.scaladsl.server
 
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ClassicActorSystemProvider
 import pekko.http.javadsl
 import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import pekko.stream.scaladsl.Flow
-
-import scala.collection.immutable
-import scala.concurrent.Future
-import scala.jdk.CollectionConverters._
 
 /**
  * The result of handling a request.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RoutingLog.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/RoutingLog.scala
@@ -14,8 +14,8 @@
 package org.apache.pekko.http.scaladsl.server
 
 import org.apache.pekko
-import pekko.event.LoggingAdapter
 import pekko.actor.{ ActorContext, ActorSystem }
+import pekko.event.LoggingAdapter
 import pekko.http.scaladsl.model.HttpRequest
 
 trait RoutingLog {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/BasicDirectives.scala
@@ -16,25 +16,24 @@ package directives
 
 import java.util.concurrent.TimeoutException
 
+import scala.collection.immutable
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
+import pekko.event.LoggingAdapter
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.Uri.Path
+import pekko.http.scaladsl.server.util.Tuple
+import pekko.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
+import pekko.http.scaladsl.util.FastFuture
+import pekko.http.scaladsl.util.FastFuture._
+import pekko.stream.Materializer
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
-
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-import scala.collection.immutable
-import pekko.event.LoggingAdapter
-import pekko.http.scaladsl.model.Uri.Path
 import pekko.util.ConstantFun.scalaIdentityFunction
-import pekko.stream.Materializer
-import pekko.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
-import pekko.http.scaladsl.server.util.Tuple
-import pekko.http.scaladsl.util.FastFuture
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.util.FastFuture._
-
-import scala.util.control.NonFatal
 
 /**
  * @groupname basic Basic directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectives.scala
@@ -14,14 +14,13 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import EntityTag._
-import HttpMethods._
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.DateTime
+import pekko.http.scaladsl.model.HttpMethods._
 import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers._
+import pekko.http.scaladsl.model.headers.EntityTag._
 
 /**
  * @groupname cachecondition Cache condition directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectives.scala
@@ -16,12 +16,12 @@ package directives
 
 import EntityTag._
 import HttpMethods._
-import StatusCodes._
-import headers._
 
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.DateTime
+import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.scaladsl.model.headers._
 
 /**
  * @groupname cachecondition Cache condition directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CacheConditionDirectives.scala
@@ -14,13 +14,14 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import EntityTag._
+import HttpMethods._
+import StatusCodes._
+import headers._
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.DateTime
-import headers._
-import HttpMethods._
-import StatusCodes._
-import EntityTag._
 
 /**
  * @groupname cachecondition Cache condition directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CodingDirectives.scala
@@ -15,14 +15,14 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import scala.collection.immutable
+import scala.util.control.NonFatal
+
 import org.apache.pekko
-import pekko.http.scaladsl.model.headers.{ HttpEncoding, HttpEncodings }
-import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.coding._
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.{ HttpEncoding, HttpEncodings }
 import pekko.stream.scaladsl.Flow
 import pekko.util.ByteString
-
-import scala.util.control.NonFatal
 
 /**
  * @groupname coding Coding directives
@@ -30,9 +30,9 @@ import scala.util.control.NonFatal
  */
 trait CodingDirectives {
   import BasicDirectives._
+  import CodingDirectives._
   import MiscDirectives._
   import RouteDirectives._
-  import CodingDirectives._
 
   // encoding
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/CookieDirectives.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import org.apache.pekko
+import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
-import pekko.http.impl.util._
 
 /**
  * @groupname cookie Cookie directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/DebuggingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/DebuggingDirectives.scala
@@ -17,8 +17,8 @@ package directives
 import org.apache.pekko
 import pekko.event.Logging._
 import pekko.event.LoggingAdapter
-import pekko.http.scaladsl.model._
 import pekko.http.javadsl
+import pekko.http.scaladsl.model._
 
 /**
  * @groupname debugging Debugging directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/ExecutionDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/ExecutionDirectives.scala
@@ -17,6 +17,7 @@ package directives
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -20,12 +20,11 @@ import java.net.{ URI, URL }
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 
-import JavaMapping.Implicits._
-
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.LoggingAdapter
 import pekko.http.impl.util._
+import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.javadsl
 import pekko.http.javadsl.{ marshalling, model }
 import pekko.http.javadsl.server.RoutingJavaMapping

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -17,33 +17,34 @@ package directives
 import java.io.File
 import java.net.{ URI, URL }
 
+import scala.annotation.tailrec
+import scala.jdk.CollectionConverters._
+
+import JavaMapping.Implicits._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.LoggingAdapter
 import pekko.http.impl.util._
 import pekko.http.javadsl
 import pekko.http.javadsl.{ marshalling, model }
-import JavaMapping.Implicits._
 import pekko.http.javadsl.server.RoutingJavaMapping
 import pekko.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
 import pekko.stream.scaladsl.{ FileIO, StreamConverters }
 
-import scala.annotation.tailrec
-import scala.jdk.CollectionConverters._
-
 /**
  * @groupname fileandresource File and resource directives
  * @groupprio fileandresource 70
  */
 trait FileAndResourceDirectives {
-  import CacheConditionDirectives._
-  import MethodDirectives._
-  import FileAndResourceDirectives._
-  import RouteDirectives._
   import BasicDirectives._
+  import CacheConditionDirectives._
+  import FileAndResourceDirectives._
+  import MethodDirectives._
   import RouteConcatenation._
+  import RouteDirectives._
 
   /**
    * Completes GET requests with the content of the given file.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -16,21 +16,20 @@ package org.apache.pekko.http.scaladsl.server.directives
 import java.io.File
 import java.nio.file.Files
 
+import scala.collection.immutable
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Failure, Success }
+
 import org.apache.pekko
 import pekko.Done
 import pekko.annotation.ApiMayChange
 import pekko.http.impl.util.StreamUtils
-import pekko.http.scaladsl.server.{ Directive, Directive1, MissingFormFieldRejection }
-import pekko.http.scaladsl.model.{ ContentType, Multipart }
-import pekko.util.ByteString
-
-import scala.collection.immutable
-import scala.concurrent.{ Future, Promise }
-import pekko.stream.scaladsl._
 import pekko.http.javadsl
+import pekko.http.scaladsl.model.{ ContentType, Multipart }
+import pekko.http.scaladsl.server.{ Directive, Directive1, MissingFormFieldRejection }
 import pekko.http.scaladsl.server.RouteResult
-
-import scala.util.{ Failure, Success }
+import pekko.stream.scaladsl._
+import pekko.util.ByteString
 
 /**
  * @groupname fileupload File upload directives
@@ -122,8 +121,8 @@ trait FileUploadDirectives {
   def fileUpload(fieldName: String): Directive1[(FileInfo, Source[ByteString, Any])] =
     entity(as[Multipart.FormData]).flatMap { formData =>
       Directive[Tuple1[(FileInfo, Source[ByteString, Any])]] { inner => ctx =>
-        import ctx.materializer
         import ctx.executionContext
+        import ctx.materializer
 
         // We complete the directive through this promise as soon as we encounter the
         // selected part. This way the inner directive can consume it, after which we will

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FormFieldDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FormFieldDirectives.scala
@@ -14,6 +14,13 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.annotation.tailrec
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.{ Failure, Success }
+
+import BasicDirectives._
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.impl.util._
@@ -21,12 +28,6 @@ import pekko.http.scaladsl.common._
 import pekko.http.scaladsl.server.directives.RouteDirectives._
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.util.FastFuture._
-
-import scala.annotation.tailrec
-import scala.collection.immutable
-import scala.concurrent.Future
-import scala.util.{ Failure, Success }
-import BasicDirectives._
 
 /**
  * @groupname form Form field directives
@@ -61,6 +62,7 @@ object FormFieldDirectives extends FormFieldDirectives {
 
   private val _formFieldSeq: Directive1[immutable.Seq[(String, String)]] = {
     import FutureDirectives._
+
     import pekko.http.scaladsl.unmarshalling._
 
     extract { ctx =>
@@ -117,6 +119,7 @@ object FormFieldDirectives extends FormFieldDirectives {
     }
 
     import Impl._
+
     import pekko.http.scaladsl.unmarshalling.{ FromStrictFormFieldUnmarshaller => FSFFU, _ }
     type FSFFOU[T] = Unmarshaller[Option[StrictForm.Field], T]
 
@@ -160,6 +163,7 @@ object FormFieldDirectives extends FormFieldDirectives {
     import BasicDirectives._
     import FutureDirectives._
     import RouteDirectives._
+
     import pekko.http.scaladsl.unmarshalling.{ FromStrictFormFieldUnmarshaller => FSFFU, _ }
 
     type SFU = FromEntityUnmarshaller[StrictForm]

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -17,8 +17,8 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.http.scaladsl.common.EntityStreamingSupport
 import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.unmarshalling.{ Unmarshaller, _ }
+import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.scaladsl.{ Flow, Keep, Source }
 import pekko.util.ByteString

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FutureDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FutureDirectives.scala
@@ -14,6 +14,9 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
 import pekko.http.scaladsl.marshalling.ToResponseMarshaller
 import pekko.http.scaladsl.server.Directives._
@@ -21,9 +24,6 @@ import pekko.http.scaladsl.server.util.Tupler
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.pattern.{ CircuitBreaker, CircuitBreakerOpenException }
 import pekko.stream.scaladsl.Sink
-
-import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
 
 // format: OFF
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -14,13 +14,13 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
 import org.apache.pekko
 import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers._
-
-import scala.reflect.ClassTag
-import scala.util.control.NonFatal
 
 /**
  * @groupname header Header directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/HostDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/HostDirectives.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import scala.util.matching.Regex
+
 import org.apache.pekko.http.impl.util._
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MarshallingDirectives.scala
@@ -19,8 +19,8 @@ import scala.util.{ Failure, Success }
 
 import org.apache.pekko
 import pekko.http.impl.util._
-import pekko.http.scaladsl.model.ExceptionWithErrorInfo
 import pekko.http.scaladsl.marshalling.ToResponseMarshaller
+import pekko.http.scaladsl.model.ExceptionWithErrorInfo
 import pekko.http.scaladsl.unmarshalling.{ FromRequestUnmarshaller, Unmarshaller }
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MethodDirectives.scala
@@ -24,9 +24,9 @@ import pekko.http.scaladsl.model.HttpMethods._
  */
 trait MethodDirectives {
   import BasicDirectives._
-  import RouteDirectives._
-  import ParameterDirectives._
   import MethodDirectives._
+  import ParameterDirectives._
+  import RouteDirectives._
 
   /**
    * Rejects all non-DELETE requests.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
@@ -14,10 +14,9 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import headers._
-
 import org.apache.pekko
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server.RequestEntityExpectedRejection
 import pekko.http.scaladsl.server.directives.BasicDirectives._
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/MiscDirectives.scala
@@ -14,11 +14,12 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import headers._
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.server.directives.BasicDirectives._
 import pekko.http.scaladsl.server.RequestEntityExpectedRejection
-import headers._
+import pekko.http.scaladsl.server.directives.BasicDirectives._
 
 /**
  * @groupname misc Miscellaneous directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -17,9 +17,10 @@ package directives
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
+
 import org.apache.pekko
-import pekko.http.scaladsl.common._
 import pekko.http.impl.util._
+import pekko.http.scaladsl.common._
 
 /**
  * @groupname param Parameter directives
@@ -75,6 +76,7 @@ object ParameterDirectives extends ParameterDirectives {
       }
 
     import Impl._
+
     import pekko.http.scaladsl.unmarshalling.{ FromStringUnmarshaller => FSU }
 
     // regular
@@ -113,8 +115,9 @@ object ParameterDirectives extends ParameterDirectives {
   /** Actual directive implementations shared between old and new API */
   private object Impl {
     import BasicDirectives._
-    import RouteDirectives._
     import FutureDirectives._
+    import RouteDirectives._
+
     import pekko.http.scaladsl.unmarshalling.{ FromStringUnmarshaller => FSU, _ }
     type FSOU[T] = Unmarshaller[Option[String], T]
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/PathDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/PathDirectives.scala
@@ -29,8 +29,8 @@ import pekko.http.scaladsl.server.directives.PathDirectives.TrailingRetryRejecti
 trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction with ToNameReceptacleEnhancements {
 
   import BasicDirectives._
-  import RouteDirectives._
   import PathMatcher._
+  import RouteDirectives._
 
   /**
    * Applies the given [[PathMatcher]] to the remaining unmatched path after consuming a leading slash.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RangeDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RangeDirectives.scala
@@ -14,17 +14,18 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.collection.immutable
+
 import org.apache.pekko
-import pekko.http.scaladsl.model.StatusCodes._
+import pekko.http.impl.util._
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server.RouteResult.Complete
-import pekko.http.impl.util._
-import pekko.stream.scaladsl._
-import scala.collection.immutable
-import pekko.util.ByteString
-import pekko.stream.SourceShape
 import pekko.stream.OverflowStrategy
+import pekko.stream.SourceShape
+import pekko.stream.scaladsl._
+import pekko.util.ByteString
 
 /**
  * @groupname range Range directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RespondWithDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RespondWithDirectives.scala
@@ -14,9 +14,10 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
+import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
-import scala.collection.immutable
 
 /**
  * @groupname response Response directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectives.scala
@@ -14,12 +14,14 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import scala.concurrent.Future
 import scala.collection.immutable
+import scala.concurrent.Future
+
+import StatusCodes._
+
 import org.apache.pekko
 import pekko.http.scaladsl.marshalling.{ ToEntityMarshaller, ToResponseMarshallable }
 import pekko.http.scaladsl.model._
-import StatusCodes._
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/RouteDirectives.scala
@@ -17,11 +17,10 @@ package directives
 import scala.collection.immutable
 import scala.concurrent.Future
 
-import StatusCodes._
-
 import org.apache.pekko
 import pekko.http.scaladsl.marshalling.{ ToEntityMarshaller, ToResponseMarshallable }
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.StatusCodes._
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -14,16 +14,16 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import scala.reflect.ClassTag
 import scala.concurrent.Future
+import scala.reflect.ClassTag
+import scala.util.Success
+
 import org.apache.pekko
 import pekko.http.impl.util._
-import pekko.http.scaladsl.util.FastFuture
-import pekko.http.scaladsl.util.FastFuture._
 import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server.AuthenticationFailedRejection.{ CredentialsMissing, CredentialsRejected }
-
-import scala.util.Success
+import pekko.http.scaladsl.util.FastFuture
+import pekko.http.scaladsl.util.FastFuture._
 
 /**
  * Provides directives for securing an inner route using the standard Http authentication headers [[`WWW-Authenticate`]]
@@ -38,8 +38,8 @@ import scala.util.Success
  */
 trait SecurityDirectives {
   import BasicDirectives._
-  import HeaderDirectives._
   import FutureDirectives._
+  import HeaderDirectives._
   import RouteDirectives._
 
   // #authentication-result

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/TimeoutDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/TimeoutDirectives.scala
@@ -13,11 +13,12 @@
 
 package org.apache.pekko.http.scaladsl.server.directives
 
+import scala.concurrent.duration.Duration
+
 import org.apache.pekko
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.`Timeout-Access`
 import pekko.http.scaladsl.server.{ Directive, Directive0, Directive1 }
-import scala.concurrent.duration.Duration
 
 /**
  * @groupname timeout Timeout directives

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.http.scaladsl.settings
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
 import pekko.http.impl.settings.RoutingSettingsImpl
+
 import com.typesafe.config.Config
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSentEventSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSentEventSettings.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.http.scaladsl.settings
 import org.apache.pekko
 import pekko.annotation.{ ApiMayChange, DoNotInherit }
 import pekko.http.impl.settings.ServerSentEventSettingsImpl
+
 import com.typesafe.config.Config
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/GenericUnmarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/GenericUnmarshallers.scala
@@ -13,13 +13,13 @@
 
 package org.apache.pekko.http.scaladsl.unmarshalling
 
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.EitherUnmarshallingException
 import pekko.http.scaladsl.util.FastFuture
-
-import scala.concurrent.Future
-import scala.reflect.ClassTag
 
 trait GenericUnmarshallers extends LowerPriorityGenericUnmarshallers {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
@@ -13,21 +13,21 @@
 
 package org.apache.pekko.http.scaladsl.unmarshalling
 
+import scala.collection.immutable
+import scala.collection.immutable.VectorBuilder
+
 import org.apache.pekko
 import pekko.event.{ LoggingAdapter, NoLogging }
 import pekko.http.impl.engine.parsing.BodyPartParser
 import pekko.http.impl.util.StreamUtils
+import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.HttpCharsets._
 import pekko.http.scaladsl.model.MediaRanges._
 import pekko.http.scaladsl.model.MediaTypes._
-import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.settings.ParserSettings
 import pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import pekko.http.scaladsl.util.FastFuture
 import pekko.stream.scaladsl._
-
-import scala.collection.immutable
-import scala.collection.immutable.VectorBuilder
 
 /**
  * Provides [[pekko.http.scaladsl.model.Multipart]] marshallers.

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala
@@ -14,9 +14,9 @@
 package org.apache.pekko.http.scaladsl.unmarshalling
 
 import org.apache.pekko
-import pekko.util.ByteString
-import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.util.FastFuture
+import pekko.util.ByteString
 
 trait PredefinedFromEntityUnmarshallers extends MultipartUnmarshallers {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.http.scaladsl.unmarshalling
 import java.util.UUID
 
 import scala.collection.immutable
+
 import org.apache.pekko
 import pekko.http.scaladsl.util.FastFuture
 import pekko.util.ByteString

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshal.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshal.scala
@@ -13,9 +13,9 @@
 
 package org.apache.pekko.http.scaladsl.unmarshalling
 
-import org.apache.pekko.stream.Materializer
-
 import scala.concurrent.{ ExecutionContext, Future }
+
+import org.apache.pekko.stream.Materializer
 
 object Unmarshal {
   def apply[T](value: T): Unmarshal[T] = new Unmarshal(value)

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -13,19 +13,19 @@
 
 package org.apache.pekko.http.scaladsl.unmarshalling
 
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+import scala.util.control.{ NoStackTrace, NonFatal }
+
 import org.apache.pekko
 import pekko.event.Logging
 import pekko.http.{ javadsl => jm }
+import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.util.FastFuture
 import pekko.http.scaladsl.util.FastFuture._
-import pekko.http.impl.util.JavaMapping.Implicits._
 import pekko.stream.Materializer
-
-import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters._
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.control.{ NoStackTrace, NonFatal }
 
 trait Unmarshaller[-A, B] extends jm.unmarshalling.Unmarshaller[A, B] {
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParser.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/LineParser.scala
@@ -16,14 +16,15 @@ package scaladsl
 package unmarshalling
 package sse
 
+import scala.annotation.tailrec
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.event.Logging
 import pekko.http.scaladsl.settings.OversizedSseStrategy
-import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.util.ByteString
-import scala.annotation.tailrec
 
 /** INTERNAL API */
 @InternalApi

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
@@ -21,8 +21,8 @@ import pekko.annotation.InternalApi
 import pekko.event.Logging
 import pekko.http.scaladsl.model.sse.ServerSentEvent
 import pekko.http.scaladsl.settings.OversizedSseStrategy
-import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 
 /** INTERNAL API */
 @InternalApi

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -15,17 +15,19 @@ package org.apache.pekko.http.impl.engine.http2
 
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.sys.process._
+
 import org.apache.pekko
 import pekko.http.impl.util.{ ExampleHttpContexts, WithLogCapturing }
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.server.Directives
 import pekko.testkit._
 import pekko.util.ByteString
-import org.scalatest.concurrent.ScalaFutures
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-import scala.sys.process._
+import org.scalatest.concurrent.ScalaFutures
 
 class H2SpecIntegrationSpec extends PekkoFreeSpec(
       """

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2cUpgradeSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2cUpgradeSpec.scala
@@ -13,18 +13,18 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.annotation.tailrec
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.Http2Protocol.SettingIdentifier
 import pekko.http.impl.engine.http2.Http2Protocol.SettingIdentifier._
 import pekko.http.impl.util._
-import pekko.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import pekko.http.scaladsl.HttpConnectionContext
+import pekko.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import pekko.stream.scaladsl.{ Source, Tcp }
 import pekko.util.ByteString
-
-import scala.annotation.tailrec
-import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class H2cUpgradeSpec extends PekkoSpecWithMaterializer("""
     pekko.http.server.preview.enable-http2 = on

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HPackEncodingSupport.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HPackEncodingSupport.scala
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.io.ByteArrayOutputStream
+
 import org.apache.pekko
 import pekko.http.impl.util.StringRendering
 import pekko.http.scaladsl.model.{ HttpHeader, HttpRequest, HttpResponse }
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.shaded.com.twitter.hpack.Encoder
 import pekko.util.ByteString
-
-import java.io.ByteArrayOutputStream
 
 /** Helps with a encoding headers to HPACK from Pekko HTTP model */
 trait HPackEncodingSupport {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -13,10 +13,15 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.collection.immutable
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.http.impl.engine.HttpIdleTimeoutException
 import pekko.http.impl.engine.ws.ByteStringSinkProbe
 import pekko.http.impl.util.{ ExampleHttpContexts, PekkoSpecWithMaterializer }
+import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.model.{
   headers,
   AttributeKey,
@@ -34,19 +39,15 @@ import pekko.http.scaladsl.model.{
 }
 import pekko.http.scaladsl.model.headers.HttpEncodings
 import pekko.http.scaladsl.settings.ClientConnectionSettings
-import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.settings.ServerSettings
+import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.stream.StreamTcpException
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.{ TestPublisher, TestSubscriber }
 import pekko.testkit.TestProbe
 import pekko.util.ByteString
-import org.scalatest.concurrent.ScalaFutures
 
-import scala.collection.immutable
-import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
+import org.scalatest.concurrent.ScalaFutures
 
 class Http2ClientServerSpec extends PekkoSpecWithMaterializer(
       """pekko.http.server.http2.log-frames = on

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -13,17 +13,18 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.collection.immutable.VectorBuilder
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.hpack.ByteStringInputStream
-import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.http.shaded.com.twitter.hpack._
 import pekko.stream.Materializer
 import pekko.stream.scaladsl.Source
 import pekko.util.ByteString
-import org.scalatest.concurrent.ScalaFutures
 
-import scala.collection.immutable.VectorBuilder
+import org.scalatest.concurrent.ScalaFutures
 
 /** Helper that allows automatic HPACK encoding/decoding for wire sends / expectations */
 trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSending with HPackEncodingSupport

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2FrameProbe.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2FrameProbe.scala
@@ -13,6 +13,10 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.annotation.tailrec
+import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.impl.engine.http2.FrameEvent.SettingsFrame
@@ -26,11 +30,7 @@ import pekko.stream.impl.io.ByteStringParser.ByteReader
 import pekko.stream.scaladsl.Sink
 import pekko.util.ByteString
 
-import scala.annotation.tailrec
 import org.scalatest.matchers.should.Matchers
-
-import scala.concurrent.duration.FiniteDuration
-import scala.reflect.ClassTag
 
 private[http2] trait Http2FrameProbe {
   def sink: Sink[ByteString, Any]

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -13,11 +13,18 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.net.InetSocketAddress
+
+import scala.collection.immutable
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.event.Logging
 import pekko.http.impl.engine.ws.ByteStringSinkProbe
 import pekko.http.impl.util.{ ExampleHttpContexts, PekkoSpecWithMaterializer }
+import pekko.http.scaladsl.{ ClientTransport, Http }
 import pekko.http.scaladsl.model.{
   headers,
   AttributeKey,
@@ -37,21 +44,16 @@ import pekko.http.scaladsl.model.{
 import pekko.http.scaladsl.model.headers.HttpEncodings
 import pekko.http.scaladsl.settings.ClientConnectionSettings
 import pekko.http.scaladsl.settings.Http2ClientSettings
-import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.http.scaladsl.{ ClientTransport, Http }
 import pekko.http.scaladsl.settings.ServerSettings
+import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.stream.{ KillSwitches, StreamTcpException, UniqueKillSwitch }
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import pekko.stream.testkit.scaladsl.StreamTestKit
 import pekko.stream.testkit.{ TestPublisher, TestSubscriber }
+import pekko.stream.testkit.scaladsl.StreamTestKit
 import pekko.testkit.TestProbe
 import pekko.util.ByteString
-import org.scalatest.concurrent.ScalaFutures
 
-import java.net.InetSocketAddress
-import scala.collection.immutable
-import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
+import org.scalatest.concurrent.ScalaFutures
 
 class Http2PersistentClientTlsSpec extends Http2PersistentClientSpec(true)
 class Http2PersistentClientPlaintextSpec extends Http2PersistentClientSpec(false)

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.collection.immutable.Seq
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.FrameEvent.{ ParsedHeadersFrame, Setting, SettingsFrame }
 import pekko.http.impl.engine.http2.Http2Protocol.SettingIdentifier
@@ -21,8 +23,6 @@ import pekko.http.scaladsl.settings.Http2ServerSettings
 import pekko.stream.scaladsl.{ BidiFlow, Flow, Keep }
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
 import pekko.util.{ ByteString, OptionVal }
-
-import scala.collection.immutable.Seq
 
 /**
  * low-level tests testing Http2ServerDemux in isolation

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDisableFrameTypeThrottleSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerDisableFrameTypeThrottleSpec.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.nio.ByteOrder
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.Http2Protocol.FrameType
 import pekko.http.impl.engine.http2.framing.FrameRenderer
 import pekko.util.ByteStringBuilder
-
-import java.nio.ByteOrder
 
 /**
  * This tests the http2 server throttle support for rapid resets is disabled by default.

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerEnableFrameTypeThrottleSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerEnableFrameTypeThrottleSpec.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.nio.ByteOrder
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.Http2Protocol.FrameType
 import pekko.http.impl.engine.http2.framing.FrameRenderer
 import pekko.util.ByteStringBuilder
-
-import java.nio.ByteOrder
 
 /**
  * This tests the http2 server throttle support for rapid resets.

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ServerSpec.scala
@@ -13,6 +13,12 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import javax.net.ssl.SSLContext
+
+import scala.collection.immutable
+import scala.concurrent.{ Await, Promise }
+import scala.concurrent.duration._
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.http.impl.engine.http2.FrameEvent._
@@ -25,20 +31,14 @@ import pekko.http.scaladsl.model.headers.{ CacheDirectives, RawHeader }
 import pekko.http.scaladsl.settings.ServerSettings
 import pekko.stream.OverflowStrategy
 import pekko.stream.scaladsl.{ BidiFlow, Flow, Source, SourceQueueWithComplete }
+import pekko.stream.testkit.TestPublisher
 import pekko.stream.testkit.TestPublisher.ManualProbe
 import pekko.stream.testkit.scaladsl.StreamTestKit
-import pekko.stream.testkit.TestPublisher
 import pekko.testkit._
 import pekko.util.ByteString
 
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
-
-import javax.net.ssl.SSLContext
-
-import scala.collection.immutable
-import scala.concurrent.duration._
-import scala.concurrent.{ Await, Promise }
 
 /**
  * This tests the http2 server protocol logic.

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2SpecWithMaterializer.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2SpecWithMaterializer.scala
@@ -13,27 +13,27 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future }
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.event.Logging
 import pekko.http.impl.engine.http2.FrameEvent._
 import pekko.http.impl.engine.server.ServerTerminator
 import pekko.http.impl.engine.ws.ByteStringSinkProbe
-import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.http.impl.util.LogByteStringTools
+import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.settings.ServerSettings
 import pekko.stream.Attributes
 import pekko.stream.Attributes.LogLevels
 import pekko.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, Source }
+import pekko.stream.testkit.{ TestPublisher, TestSubscriber }
 import pekko.stream.testkit.TestPublisher.Probe
 import pekko.stream.testkit.scaladsl.StreamTestKit
-import pekko.stream.testkit.{ TestPublisher, TestSubscriber }
 import pekko.util.ByteString
-
-import scala.collection.immutable
-import scala.concurrent.{ ExecutionContext, Future }
 
 abstract class Http2SpecWithMaterializer(configOverrides: String) extends PekkoSpecWithMaterializer(configOverrides) {
   implicit class InWithStoppedStages(name: String) {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRenderingSpec.scala
@@ -15,20 +15,22 @@ package org.apache.pekko.http.impl.engine.http2
 
 import java.time.format.DateTimeFormatter
 
-import com.typesafe.config.ConfigFactory
+import scala.collection.immutable
+import scala.collection.immutable.Seq
+import scala.collection.immutable.VectorBuilder
+import scala.util.Try
+
 import org.apache.pekko
 import pekko.event.NoLogging
 import pekko.http.impl.engine.rendering.DateHeaderRendering
-import pekko.http.scaladsl.model.headers.{ Trailer => _, _ }
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.{ Trailer => _, _ }
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.immutable.VectorBuilder
-import scala.collection.immutable.Seq
-import scala.collection.immutable
-import scala.util.Try
+import com.typesafe.config.ConfigFactory
 
 object MyCustomHeader extends ModeledCustomHeaderCompanion[MyCustomHeader] {
   override def name: String = "custom-header"

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitchSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/ProtocolSwitchSpec.scala
@@ -14,6 +14,8 @@
 package org.apache.pekko.http.impl.engine.http2
 
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.Done
 import pekko.http.impl.engine.server.ServerTerminator
@@ -23,15 +25,14 @@ import pekko.stream.QueueOfferResult.Enqueued
 import pekko.stream.TLSProtocol._
 import pekko.stream.scaladsl.Flow
 import pekko.stream.scaladsl.Keep
-import pekko.stream.scaladsl.Source
 import pekko.stream.scaladsl.Sink
+import pekko.stream.scaladsl.Source
 import pekko.stream.scaladsl.TLSPlacebo
-import pekko.util.ByteString
 import pekko.testkit.PekkoSpec
+import pekko.util.ByteString
+
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.time.{ Milliseconds, Seconds, Span }
-
-import scala.concurrent.duration.FiniteDuration
 
 class ProtocolSwitchSpec extends PekkoSpec {
   override implicit val patience: PatienceConfig =

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/RequestParsingSpec.scala
@@ -13,22 +13,24 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.net.InetAddress
+import java.net.InetSocketAddress
+
+import FrameEvent._
+
 import org.apache.pekko
+import pekko.http.impl.engine.http2.hpack.HeaderDecompression
 import pekko.http.impl.engine.parsing.HttpHeaderParser
+import pekko.http.impl.engine.server.HttpAttributes
+import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.{ Accept, Cookie, Host }
 import pekko.http.scaladsl.settings.ServerSettings
 import pekko.stream.Attributes
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.util.{ ByteString, OptionVal }
-import org.scalatest.{ Inside, Inspectors }
-import FrameEvent._
-import pekko.http.impl.engine.http2.hpack.HeaderDecompression
-import pekko.http.impl.engine.server.HttpAttributes
-import pekko.http.impl.util.PekkoSpecWithMaterializer
 
-import java.net.InetAddress
-import java.net.InetSocketAddress
+import org.scalatest.{ Inside, Inspectors }
 
 class RequestParsingSpec extends PekkoSpecWithMaterializer with Inside with Inspectors {
   "RequestParsing" should {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpiSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpiSpec.scala
@@ -13,11 +13,18 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import java.util.UUID
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.actor.ActorSystem
-import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.http.impl.util.ExampleHttpContexts
+import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.http.impl.util.StreamUtils
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.model.AttributeKey
@@ -37,15 +44,11 @@ import pekko.stream.scaladsl.Source
 import pekko.stream.scaladsl.Tcp
 import pekko.testkit.TestKit
 import pekko.testkit.TestProbe
-import com.typesafe.config.ConfigFactory
+
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 
-import java.util.UUID
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import scala.util.Failure
-import scala.util.Success
+import com.typesafe.config.ConfigFactory
 
 object TestTelemetryImpl {
   @volatile var delegate: Option[TelemetrySpi] = None

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WindowTracking.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WindowTracking.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.http.impl.engine.http2
 
+import scala.concurrent.duration.FiniteDuration
+
 import org.apache.pekko
 import pekko.http.impl.engine.http2.Http2Protocol.FrameType
 import pekko.stream.impl.io.ByteStringParser.ByteReader
 import pekko.util.ByteString
-
-import scala.concurrent.duration.FiniteDuration
 
 trait WindowTracking extends Http2FrameProbeDelegator with Http2FrameSending {
   override def sendDATA(streamId: Int, endStream: Boolean, data: ByteString): Unit = {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
@@ -15,16 +15,16 @@ package org.apache.pekko.http.impl.engine.http2
 
 import java.util.Base64
 
+import scala.concurrent.Future
+
 import org.apache.pekko
 import pekko.http.impl.util.PekkoSpecWithMaterializer
 import pekko.http.scaladsl.Http
 import pekko.http.scaladsl.model.{ HttpProtocols, HttpRequest, HttpResponse, StatusCodes }
 import pekko.stream.OverflowStrategy
-import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.{ Keep, Source, Tcp }
+import pekko.stream.scaladsl.Sink
 import pekko.util.ByteString
-
-import scala.concurrent.Future
 
 class WithPriorKnowledgeSpec extends PekkoSpecWithMaterializer("""
     pekko.http.server.preview.enable-http2 = on

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -14,23 +14,25 @@
 package org.apache.pekko.http.impl.engine.http2
 package framing
 
+import scala.collection.immutable
+import scala.concurrent.duration._
+
+import FrameEvent._
+
 import org.apache.pekko
 import pekko.event.Logging
 import pekko.http.impl.engine.http2.Http2Protocol.ErrorCode
 import pekko.http.impl.engine.ws.BitBuilder
 import pekko.http.impl.util._
 import pekko.stream.scaladsl.{ Sink, Source }
-import pekko.util.ByteString
 import pekko.testkit._
+import pekko.util.ByteString
+
 import org.scalatest.matchers.Matcher
-
-import scala.collection.immutable
-import scala.concurrent.duration._
-
-import FrameEvent._
 
 class Http2FramingSpec extends PekkoSpecWithMaterializer {
   import BitBuilder._
+
   import pekko.http.impl.engine.http2._
 
   "The HTTP/2 parser/renderer round-trip should work for" should {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/scaladsl/Http2ServerTest.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/scaladsl/Http2ServerTest.scala
@@ -15,22 +15,23 @@ package org.apache.pekko.http.scaladsl
 
 import java.nio.file.Paths
 
-import org.apache.pekko
-import pekko.actor.ActorSystem
-import pekko.http.impl.util.ExampleHttpContexts
-import pekko.http.scaladsl.model.HttpMethods._
-import pekko.http.scaladsl.model._
-import pekko.http.scaladsl.unmarshalling.Unmarshal
-import pekko.stream.scaladsl.FileIO
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.StdIn
 import scala.util.Random
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.impl.util.ExampleHttpContexts
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.HttpMethods._
+import pekko.http.scaladsl.unmarshalling.Unmarshal
+import pekko.stream.scaladsl.FileIO
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 /**
  * App to manually test an HTTP2 server

--- a/parsing/src/main/scala-2/org/apache/pekko/macros/LogHelperMacro.scala
+++ b/parsing/src/main/scala-2/org/apache/pekko/macros/LogHelperMacro.scala
@@ -13,9 +13,9 @@
 
 package org.apache.pekko.macros
 
-import org.apache.pekko.annotation.InternalApi
-
 import scala.reflect.macros.blackbox
+
+import org.apache.pekko.annotation.InternalApi
 
 /** INTERNAL API */
 @InternalApi

--- a/project/ProjectFileIgnoreSupport.scala
+++ b/project/ProjectFileIgnoreSupport.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+import sbt.ConsoleLogger
+
+class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
+  private lazy val stdoutLogger = ConsoleLogger(System.out)
+
+  private val javaSourceDirectories = Set("java")
+
+  private val scalaSourceDirectories = Set("scala")
+
+  private lazy val ignoreConfig = {
+    require(
+      ignoreConfigFile.exists(),
+      s"Expected ignore configuration for $descriptor at ${ignoreConfigFile.getAbsolutePath} but was missing")
+    ConfigFactory.parseFile(ignoreConfigFile)
+  }
+
+  private lazy val ignoredFiles: Set[String] = {
+    import scala.collection.JavaConverters._
+    stdoutLogger.debug(s"Loading ignored-files from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
+    ignoreConfig.getStringList("ignored-files").asScala.toSet
+  }
+
+  private lazy val ignoredPackages: Set[String] = {
+    import scala.collection.JavaConverters._
+    stdoutLogger.debug(
+      s"Loading ignored-packages from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
+    ignoreConfig.getStringList("ignored-packages").asScala.toSet
+  }
+
+  def isIgnoredByFileOrPackages(file: File): Boolean =
+    isIgnoredByFile(file) || isIgnoredByPackages(file)
+
+  private def isIgnoredByFile(file: File): Boolean = {
+    val ignoredByFile = ignoredFiles(file.getName)
+    if (ignoredByFile) {
+      stdoutLogger.debug(s"$descriptor ignored file with file name:${file.getName} file:[${file.toPath}]")
+    }
+    ignoredByFile
+  }
+
+  private def isIgnoredByPackages(file: File): Boolean = {
+    val ignoredByPackages = ignoredPackages.exists(pkg => {
+      getPackageName(file.toURI.toString) match {
+        case Some(packageName) =>
+          val ignored = packageName.startsWith(pkg)
+          if (ignored) {
+            stdoutLogger.debug(
+              s"$descriptor ignored file with pkg:$pkg for package:$packageName file:[${file.toPath}] ")
+          }
+          ignored
+        case None => false
+      }
+    })
+    ignoredByPackages
+  }
+
+  private def getPackageName(fileName: String): Option[String] = {
+    def getPackageName0(sourceDirectories: Set[String]): String = {
+      import java.io.{ File => JFile }
+      val packageName = fileName
+        .split(JFile.separatorChar)
+        .dropWhile(part => !sourceDirectories(part))
+        .drop(1)
+        .dropRight(1)
+        .mkString(".")
+      packageName
+    }
+
+    fileName.split('.').lastOption match {
+      case Some(fileType) =>
+        fileType match {
+          case "java" =>
+            Option(getPackageName0(javaSourceDirectories))
+          case "scala" =>
+            Option(getPackageName0(scalaSourceDirectories))
+          case _ => None
+        }
+      case None => None
+    }
+  }
+}

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2020-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import sbt.{ AutoPlugin, PluginTrigger, Plugins }
+import scalafix.sbt.ScalafixPlugin
+
+object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
+  override lazy val trigger: PluginTrigger = allRequirements
+
+  override lazy val requires: Plugins = ScalafixPlugin
+
+  import sbt._
+  import scalafix.sbt.ScalafixPlugin.autoImport.scalafixDependencies
+  override lazy val projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
+    ThisBuild / scalafixDependencies ++= Seq(
+      "com.nequissimus" %% "sort-imports" % "0.6.1",
+      // https://github.com/ohze/scala-rewrites
+      // an extended version of https://github.com/scala/scala-rewrites
+      "com.sandinh" %% "scala-rewrites" % "0.1.10-sd")
+  }
+}

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -23,9 +23,6 @@ object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
   import scalafix.sbt.ScalafixPlugin.autoImport.scalafixDependencies
   override lazy val projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
     ThisBuild / scalafixDependencies ++= Seq(
-      "com.nequissimus" %% "sort-imports" % "0.6.1",
-      // https://github.com/ohze/scala-rewrites
-      // an extended version of https://github.com/scala/scala-rewrites
-      "com.sandinh" %% "scala-rewrites" % "0.1.10-sd")
+      "com.nequissimus" %% "sort-imports" % "0.6.1")
   }
 }

--- a/project/ScalafixSupport.scala
+++ b/project/ScalafixSupport.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import sbt._
+
+import Keys._
+
+trait ScalafixSupport {
+  private val ignoreConfigFileName: String = ".scalafix.conf"
+  private val descriptor: String = "scalafix"
+
+  protected def ignore(configKey: ConfigKey): Def.Setting[Task[Seq[File]]] = {
+    import scalafix.sbt.ScalafixPlugin.autoImport._
+
+    configKey / scalafix / unmanagedSources := {
+      val ignoreSupport =
+        new ProjectFileIgnoreSupport((ThisBuild / baseDirectory).value / ignoreConfigFileName, descriptor)
+
+      (configKey / scalafix / unmanagedSources).value.filterNot(file => ignoreSupport.isIgnoredByFileOrPackages(file))
+    }
+  }
+
+  def addProjectCommandsIfAbsent(alias: String, value: String): Def.Setting[Seq[Command]] = {
+    commands := {
+      val currentCommands = commands.value.flatMap(_.nameOption).toSet
+      val isPresent = currentCommands(alias)
+      if (isPresent)
+        commands.value
+      else
+        commands.value :+ BasicCommands.newAlias(name = alias, value = value)
+    }
+  }
+
+  def updateProjectCommands(alias: String, value: String): Def.Setting[Seq[Command]] = {
+    commands := {
+      commands.value.filterNot(_.nameOption.contains("alias")) :+ BasicCommands.newAlias(name = alias, value = value)
+    }
+  }
+}
+
+object ScalafixSupport {
+  lazy val fixTestScope: Boolean = System.getProperty("pekko.scalafix.fixTestScope", "false").toBoolean
+}


### PR DESCRIPTION
* Demo of #790 
* I changed some of the imports so that the sortImports can handle them (usually by more fully qualifying the imports)
* CustomMediaTypesSpec is used in our docs and none of the features that I tried that were meant to disable scalafix stopped it being processed - I think I managed to get it to a state where it still works for paradox but where scalafix has processed it