### PR TITLE
more performant boundary check

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
@@ -376,7 +376,7 @@ private[http] object BodyPartParser {
           val newIndex = index + boundary.length
           byteAt(byteString, newIndex) match {
             case CR =>
-              if (byteAt(byteString, newIndex + 1) == LF) CR else 0
+              if (byteAt(byteString, newIndex + 1) == LF) CR else findBoundary(index + 1)
             case LF => LF
             case _  => findBoundary(index + 1)
           }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
@@ -354,16 +354,16 @@ private[http] object BodyPartParser {
   }
 
   case class UndefinedEndOfLineConfiguration(boundary: String) extends EndOfLineConfiguration {
+    import HttpConstants._
+
     override def eol: String = "\r\n"
-    private final val CR: Byte = 13
-    private final val LF: Byte = 10
 
     override def defineOnce(byteString: ByteString): EndOfLineConfiguration = {
       // Hypothesis: There is either CRLF or LF as EOL, no mix possible
       checkForBoundary(byteString) match {
-        case CR => DefinedEndOfLineConfiguration("\r\n", boundary)
-        case LF => DefinedEndOfLineConfiguration("\n", boundary)
-        case _  => this
+        case CR_BYTE => DefinedEndOfLineConfiguration("\r\n", boundary)
+        case LF_BYTE => DefinedEndOfLineConfiguration("\n", boundary)
+        case _       => this
       }
     }
 
@@ -375,10 +375,10 @@ private[http] object BodyPartParser {
         if (index != -1) {
           val newIndex = index + boundary.length
           byteAt(byteString, newIndex) match {
-            case CR =>
-              if (byteAt(byteString, newIndex + 1) == LF) CR else findBoundary(index + 1)
-            case LF => LF
-            case _  => findBoundary(index + 1)
+            case CR_BYTE =>
+              if (byteAt(byteString, newIndex + 1) == LF_BYTE) CR_BYTE else findBoundary(index + 1)
+            case LF_BYTE => LF_BYTE
+            case _       => findBoundary(index + 1)
           }
         } else 0
       }

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/BodyPartParser.scala
@@ -355,8 +355,8 @@ private[http] object BodyPartParser {
 
   case class UndefinedEndOfLineConfiguration(boundary: String) extends EndOfLineConfiguration {
     override def eol: String = "\r\n"
-    private val CR: Byte = 13
-    private val LF: Byte = 10
+    private final val CR: Byte = 13
+    private final val LF: Byte = 10
 
     override def defineOnce(byteString: ByteString): EndOfLineConfiguration = {
       // Hypothesis: There is either CRLF or LF as EOL, no mix possible

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/HttpConstants.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/HttpConstants.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.impl.util
+
+import org.apache.pekko.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * This object contains HTTP related constants that are used in various places.
+ * It is not intended to be used outside of the HTTP implementation.
+ */
+@InternalApi
+private[http] object HttpConstants {
+  final val CR_BYTE: Byte = 13
+  final val LF_BYTE: Byte = 10
+}


### PR DESCRIPTION
* tries to avoid passing the bytestring twice
* need to debug some broken tests