### PR TITLE
shared character toLowerCase function

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/CommonActions.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/CommonActions.scala
@@ -80,7 +80,7 @@ private[parser] trait CommonActions {
         val char2 = str2.charAt(at)
 
         (char1 | char2) < 0x80 &&
-        Character.toLowerCase(char1) == Character.toLowerCase(char2) &&
+        CharUtils.toLowerCase(char1) == CharUtils.toLowerCase(char2) &&
         stringEquals(at + 1, length)
       } else true
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/UriParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/parser/UriParser.scala
@@ -16,13 +16,13 @@ package org.apache.pekko.http.impl.model.parser
 import java.nio.charset.Charset
 
 import org.apache.pekko
-import org.parboiled2._
-import pekko.http.impl.util.{ enhanceString_, StringRendering }
+import pekko.annotation.InternalApi
+import pekko.http.impl.util.{ enhanceString_, CharUtils => CU, StringRendering }
 import pekko.http.scaladsl.model.{ Uri, UriRendering }
 import pekko.http.scaladsl.model.headers.HttpOrigin
-import Parser.DeliveryScheme.Either
 import Uri._
-import pekko.annotation.InternalApi
+import org.parboiled2._
+import org.parboiled2.Parser.DeliveryScheme.Either
 
 /**
  * INTERNAL API
@@ -365,7 +365,7 @@ private[http] final class UriParser(
 
   ///////////// helpers /////////////
 
-  private def appendLowered(): Rule0 = rule { run(sb.append(CharUtils.toLowerCase(lastChar))) }
+  private def appendLowered(): Rule0 = rule { run(sb.append(CU.toLowerCase(lastChar))) }
 
   private def savePath() = rule { run(setPath(Path(sb.toString, uriParsingCharset))) }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/CharUtils.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/CharUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.http.impl.util
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+
+@InternalApi
+private[http] object CharUtils {
+
+  /**
+   * Internal Pekko HTTP Use only.
+   *
+   * Efficiently lower-cases the given character.
+   * Note: only works for 7-bit ASCII letters (which is enough for header names)
+   */
+  final def toLowerCase(c: Char): Char =
+    if (c >= 'A' && c <= 'Z') (c + 0x20 /* - 'A' + 'a' */ ).toChar else c
+
+}

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMessage.scala
@@ -13,31 +13,29 @@
 
 package org.apache.pekko.http.scaladsl.model
 
-import org.apache.pekko
-import pekko.stream.scaladsl.Flow
-import pekko.stream.{ FlowShape, Graph, Materializer, SystemMaterializer }
 import java.io.File
 import java.nio.file.Path
 import java.lang.{ Iterable => JIterable }
 import java.util.Optional
 import java.util.concurrent.{ CompletionStage, Executor }
 
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.annotation.tailrec
 import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 import scala.reflect.{ classTag, ClassTag }
+
+import org.apache.pekko
 import pekko.Done
 import pekko.actor.ClassicActorSystemProvider
-import org.parboiled2.CharUtils
 import pekko.util.{ ByteString, HashCode, OptionVal }
 import pekko.http.impl.util._
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.scaladsl.util.FastFuture._
 import pekko.http.scaladsl.model.headers._
-
-import scala.annotation.tailrec
-import scala.concurrent.duration._
-import scala.jdk.FutureConverters._
+import pekko.stream.scaladsl.Flow
+import pekko.stream.{ FlowShape, Graph, Materializer, SystemMaterializer }
 
 /**
  * Common base class of HttpRequest and HttpResponse.


### PR DESCRIPTION
current code uses 3 different ways to lowercase a char
* parboiled2 CharUtils method
* an internal method on HttpHeaderParser
* uses Java built-in Character.toLowerCase

I did a jmh benchmark in my pekko-bench project
https://github.com/pjfanning/pekko-bench/blob/main/src/main/scala/example/LowerCaseBench.scala

And this showed that function in HttpHeaderParser was better than or matched the perf of the others on all Java versions.
Parboiled2 was always slower. The Java built-in was as good for Java 21 and 25 but slowest approach in java 17 and below.

This change switches all code to use the pekko-http internal method.
