### PR TITLE
compiler warning about varargs

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/UriJavaAccessor.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/UriJavaAccessor.scala
@@ -40,7 +40,8 @@ private[http] object UriJavaAccessor {
   def hostApply(string: String, charset: Charset): Host = Uri.Host(string, charset = charset)
   def emptyHost: Uri.Host = Uri.Host.Empty
 
-  def queryApply(params: Array[pekko.japi.Pair[String, String]]): Uri.Query = Uri.Query(ArraySeq.unsafeWrapArray(params.map(_.toScala)): _*)
+  def queryApply(params: Array[pekko.japi.Pair[String, String]]): Uri.Query =
+    Uri.Query(ArraySeq.unsafeWrapArray(params.map(_.toScala)): _*)
   def queryApply(params: java.util.Map[String, String]): Uri.Query = Uri.Query(params.asScala.toSeq: _*)
   def queryApply(string: String, mode: Uri.ParsingMode): Uri.Query = Uri.Query(string, mode = mode)
   def queryApply(string: String, charset: Charset): Uri.Query = Uri.Query(string, charset = charset)

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/model/UriJavaAccessor.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/model/UriJavaAccessor.scala
@@ -13,11 +13,14 @@
 
 package org.apache.pekko.http.impl.model
 
+import java.nio.charset.Charset
+
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model.Uri
 import pekko.http.scaladsl.model.Uri.Host
-import java.nio.charset.Charset
+
+import scala.collection.immutable.ArraySeq
 
 /**
  * INTERNAL API.
@@ -37,7 +40,7 @@ private[http] object UriJavaAccessor {
   def hostApply(string: String, charset: Charset): Host = Uri.Host(string, charset = charset)
   def emptyHost: Uri.Host = Uri.Host.Empty
 
-  def queryApply(params: Array[pekko.japi.Pair[String, String]]): Uri.Query = Uri.Query(params.map(_.toScala): _*)
+  def queryApply(params: Array[pekko.japi.Pair[String, String]]): Uri.Query = Uri.Query(ArraySeq.unsafeWrapArray(params.map(_.toScala)): _*)
   def queryApply(params: java.util.Map[String, String]): Uri.Query = Uri.Query(params.asScala.toSeq: _*)
   def queryApply(string: String, mode: Uri.ParsingMode): Uri.Query = Uri.Query(string, mode = mode)
   def queryApply(string: String, charset: Charset): Uri.Query = Uri.Query(string, charset = charset)

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
@@ -20,6 +20,7 @@ import java.nio.charset.Charset
 
 import scala.annotation.tailrec
 import scala.collection.{ immutable, mutable }
+
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
 import org.parboiled2.{ CharPredicate, CharUtils, ParserInput }
@@ -504,7 +505,7 @@ object Uri {
     def apply(byte1: Byte, byte2: Byte, byte3: Byte, byte4: Byte): IPv4Host = apply(Array(byte1, byte2, byte3, byte4))
     def apply(bytes: Array[Byte]): IPv4Host = apply(bytes, bytes.map(_ & 0xFF).mkString("."))
 
-    private[http] def apply(bytes: Array[Byte], address: String): IPv4Host = IPv4Host(immutable.Seq(bytes: _*), address)
+    private[http] def apply(bytes: Array[Byte], address: String): IPv4Host = IPv4Host(immutable.ArraySeq.unsafeWrapArray(bytes), address)
   }
   final case class IPv6Host private (bytes: immutable.Seq[Byte], address: String) extends NonEmptyHost {
     require(bytes.length == 16, "bytes array must have length 16")
@@ -526,7 +527,7 @@ object Uri {
       require(bytes.length == 32, "`bytes` must be a 32 character hex string")
       apply(bytes.toCharArray.grouped(2).map(s => (hex(s(0)) * 16 + hex(s(1))).toByte).toArray, address)
     }
-    private[http] def apply(bytes: Array[Byte], address: String): IPv6Host = apply(immutable.Seq(bytes: _*), address)
+    private[http] def apply(bytes: Array[Byte], address: String): IPv6Host = apply(immutable.ArraySeq.unsafeWrapArray(bytes), address)
   }
   final case class NamedHost(address: String) extends NonEmptyHost {
     def equalsIgnoreCase(other: Host): Boolean = other match {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
@@ -23,13 +23,13 @@ import scala.collection.{ immutable, mutable }
 
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
-import org.parboiled2.{ CharPredicate, CharUtils, ParserInput }
 import pekko.http.ccompat.{ Builder, QuerySeqOptimized }
 import pekko.http.javadsl.{ model => jm }
 import pekko.http.impl.model.parser.UriParser
 import pekko.http.impl.model.parser.CharacterClasses._
 import pekko.http.impl.util._
 import Uri._
+import org.parboiled2.{ CharPredicate, CharUtils, ParserInput }
 
 /**
  * An immutable model of an internet URI as defined by https://tools.ietf.org/html/rfc3986.
@@ -506,7 +506,7 @@ object Uri {
     def apply(bytes: Array[Byte]): IPv4Host = apply(bytes, bytes.map(_ & 0xFF).mkString("."))
 
     private[http] def apply(bytes: Array[Byte], address: String): IPv4Host =
-      IPv4Host(immutable.ArraySeq.unsafeWrapArray(bytes), address)
+      IPv4Host(bytes.toSeq, address)
   }
   final case class IPv6Host private (bytes: immutable.Seq[Byte], address: String) extends NonEmptyHost {
     require(bytes.length == 16, "bytes array must have length 16")
@@ -526,10 +526,10 @@ object Uri {
     private[http] def apply(bytes: String, address: String): IPv6Host = {
       import CharUtils.{ hexValue => hex }
       require(bytes.length == 32, "`bytes` must be a 32 character hex string")
-      apply(bytes.toCharArray.grouped(2).map(s => (hex(s(0)) * 16 + hex(s(1))).toByte).toArray, address)
+      apply(bytes.toCharArray.grouped(2).map(s => (hex(s(0)) * 16 + hex(s(1))).toByte).toSeq, address)
     }
     private[http] def apply(bytes: Array[Byte], address: String): IPv6Host =
-      apply(immutable.ArraySeq.unsafeWrapArray(bytes), address)
+      apply(bytes.toSeq, address)
   }
   final case class NamedHost(address: String) extends NonEmptyHost {
     def equalsIgnoreCase(other: Host): Boolean = other match {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/Uri.scala
@@ -505,7 +505,8 @@ object Uri {
     def apply(byte1: Byte, byte2: Byte, byte3: Byte, byte4: Byte): IPv4Host = apply(Array(byte1, byte2, byte3, byte4))
     def apply(bytes: Array[Byte]): IPv4Host = apply(bytes, bytes.map(_ & 0xFF).mkString("."))
 
-    private[http] def apply(bytes: Array[Byte], address: String): IPv4Host = IPv4Host(immutable.ArraySeq.unsafeWrapArray(bytes), address)
+    private[http] def apply(bytes: Array[Byte], address: String): IPv4Host =
+      IPv4Host(immutable.ArraySeq.unsafeWrapArray(bytes), address)
   }
   final case class IPv6Host private (bytes: immutable.Seq[Byte], address: String) extends NonEmptyHost {
     require(bytes.length == 16, "bytes array must have length 16")
@@ -527,7 +528,8 @@ object Uri {
       require(bytes.length == 32, "`bytes` must be a 32 character hex string")
       apply(bytes.toCharArray.grouped(2).map(s => (hex(s(0)) * 16 + hex(s(1))).toByte).toArray, address)
     }
-    private[http] def apply(bytes: Array[Byte], address: String): IPv6Host = apply(immutable.ArraySeq.unsafeWrapArray(bytes), address)
+    private[http] def apply(bytes: Array[Byte], address: String): IPv6Host =
+      apply(immutable.ArraySeq.unsafeWrapArray(bytes), address)
   }
   final case class NamedHost(address: String) extends NonEmptyHost {
     def equalsIgnoreCase(other: Host): Boolean = other match {


### PR DESCRIPTION
issues like
```
[warn] /home/runner/work/pekko-http/pekko-http/http-core/src/main/scala/org/apache/pekko/http/impl/model/UriJavaAccessor.scala:40:99: Passing an explicit array value to a Scala varargs method is deprecated (since 2.13.0) and will result in a defensive copy; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
```