### PR TITLE
Add JDK 25 to nightly workflow matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         SCALA_VERSION: [2.13, 3]
-        JDK: [17, 21]
+        JDK: [17, 21, 25]
         PEKKO_VERSION: ['default']
     steps:
       - name: Checkout


### PR DESCRIPTION
I tested pekko-http with jdk 25 and it seemed to work ok