### PR TITLE
add pekko.http.server.enable-http2 config and deprecate preview settings

### DIFF
--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -20,6 +20,12 @@ pekko.http {
     # the request, no `Server` header will be rendered at all.
     server-header = pekko-http/${pekko.http.version}
 
+    # If this setting is enabled `Http().newServerAt(...).bind` and `bindSync`
+    # will be enabled to use HTTP/2.
+    #
+    # `Http().newServerAt(...).bindFlow` and `connectionSource()` are not supported.
+    enable-http2 = off
+
     # "PREVIEW" features that are not yet fully production ready.
     # These flags can change or be removed between patch releases.
     preview {
@@ -27,7 +33,9 @@ pekko.http {
       # will be enabled to use HTTP/2.
       #
       # `Http().newServerAt(...).bindFlow` and `connectionSource()` are not supported.
-      enable-http2 = off
+      #
+      # Note that this setting is ignored if `pekko.http.server.enable-http2` is set to `on`.
+      enable-http2 = ${pekko.http.server.enable-http2}
     }
 
     # The time after which an idle connection will be automatically closed.

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ServerSettingsImpl.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/settings/ServerSettingsImpl.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.http.impl.settings
 
 import scala.language.implicitConversions
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.Try
@@ -36,7 +37,7 @@ import pekko.io.Inet.SocketOption
 @InternalApi
 private[pekko] final case class ServerSettingsImpl(
     serverHeader: Option[Server],
-    previewServerSettings: PreviewServerSettings,
+    @nowarn("msg=deprecated") previewServerSettings: PreviewServerSettings,
     timeouts: ServerSettings.Timeouts,
     maxConnections: Int,
     pipeliningLimit: Int,
@@ -56,7 +57,8 @@ private[pekko] final case class ServerSettingsImpl(
     defaultHttpsPort: Int,
     terminationDeadlineExceededResponse: HttpResponse,
     parsingErrorHandler: String,
-    streamCancellationDelay: FiniteDuration) extends ServerSettings {
+    streamCancellationDelay: FiniteDuration,
+    enableHttp2: Boolean) extends ServerSettings {
 
   require(0 < maxConnections, "max-connections must be > 0")
   require(0 < pipeliningLimit && pipeliningLimit <= 1024, "pipelining-limit must be > 0 and <= 1024")
@@ -90,9 +92,10 @@ private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSett
 
   def fromSubConfig(root: Config, c: Config) = {
     val parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing"))
+    val previewSettings = PreviewServerSettingsImpl.fromSubConfig(root, c.getConfig("preview"))
     new ServerSettingsImpl(
       c.getString("server-header").toOption.map(Server(_)),
-      PreviewServerSettingsImpl.fromSubConfig(root, c.getConfig("preview")),
+      previewSettings,
       Timeouts(
         c.getPotentiallyInfiniteDuration("idle-timeout"),
         if (c.getString("request-timeout") == "off") Duration.Zero
@@ -123,7 +126,8 @@ private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSett
       c.getInt("default-https-port"),
       terminationDeadlineExceededResponseFrom(c),
       c.getString("parsing.error-handler"),
-      c.getFiniteDuration("stream-cancellation-delay"))
+      c.getFiniteDuration("stream-cancellation-delay"),
+      c.getBoolean("enable-http2") || previewSettings.enableHttp2)
   }
 
   private def terminationDeadlineExceededResponseFrom(c: Config): HttpResponse = {

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/PreviewServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/PreviewServerSettings.scala
@@ -25,8 +25,12 @@ import com.typesafe.config.Config
  * Options that are in "preview" or "early access" mode.
  * These options may change and/or be removed within patch releases
  * without early notice (e.g. by moving them into a stable supported place).
+ *
+ * @deprecated PreviewServerSettings is deprecated, use pekko.http.javadsl.settings.ServerSettings instead (since 2.0.0)
  */
 @ApiMayChange @DoNotInherit
+@Deprecated
+@deprecated("PreviewServerSettings is deprecated, use pekko.http.javadsl.settings.ServerSettings instead", "2.0.0")
 abstract class PreviewServerSettings private[pekko] () { self: PreviewServerSettingsImpl =>
 
   /**

--- a/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/javadsl/settings/ServerSettings.scala
@@ -34,6 +34,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
  */
 @DoNotInherit abstract class ServerSettings { self: ServerSettingsImpl =>
   def getServerHeader: Optional[Server]
+  @deprecated("the preview server settings are now integrated into the main server settings", "2.0.0")
   def getPreviewServerSettings: PreviewServerSettings
   def getTimeouts: ServerSettings.Timeouts
   def getMaxConnections: Int
@@ -55,11 +56,17 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getTerminationDeadlineExceededResponse: pekko.http.javadsl.model.HttpResponse
   def getParsingErrorHandler: String
   def getStreamCancellationDelay: FiniteDuration
+  /**
+   * Configures the Http extension to bind using HTTP/2 if given an
+   * [[pekko.http.scaladsl.HttpsConnectionContext]]. Otherwise binds as plain HTTP.
+   */
+  def enableHttp2: Boolean
 
   // ---
 
   def withServerHeader(newValue: Optional[Server]): ServerSettings =
     self.copy(serverHeader = newValue.toScala.map(_.asScala))
+  @deprecated("the preview server settings are now integrated into the main server settings", "2.0.0")
   def withPreviewServerSettings(newValue: PreviewServerSettings): ServerSettings =
     self.copy(previewServerSettings = newValue.asScala)
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue.asScala)
@@ -87,6 +94,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withParsingErrorHandler(newValue: String): ServerSettings = self.copy(parsingErrorHandler = parsingErrorHandler)
   def withStreamCancellationDelay(newValue: FiniteDuration): ServerSettings =
     self.copy(streamCancellationDelay = newValue)
+  def withEnableHttp2(newValue: Boolean): ServerSettings = self.copy(enableHttp2 = newValue)
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/Http.scala
@@ -180,7 +180,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
       connectionContext: ConnectionContext,
       settings: ServerSettings,
       log: LoggingAdapter): Source[Http.IncomingConnection, Future[ServerBinding]] = {
-    if (settings.previewServerSettings.enableHttp2)
+    if (settings.enableHttp2)
       log.warning(
         s"Binding with a connection source not supported with HTTP/2. Falling back to HTTP/1.1 for port [$port]")
 
@@ -221,7 +221,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
       connectionContext: ConnectionContext,
       settings: ServerSettings,
       log: LoggingAdapter)(implicit fm: Materializer): Future[ServerBinding] = {
-    if (settings.previewServerSettings.enableHttp2)
+    if (settings.enableHttp2)
       log.warning(
         s"Binding with a connection source not supported with HTTP/2. Falling back to HTTP/1.1 for port [$port].")
 
@@ -282,7 +282,7 @@ class HttpExt @InternalStableApi /* constructor signature is hardcoded in Teleme
       settings: ServerSettings,
       parallelism: Int,
       log: LoggingAdapter)(implicit fm: Materializer): Future[ServerBinding] = {
-    if (settings.previewServerSettings.enableHttp2) {
+    if (settings.enableHttp2) {
       log.debug("Binding server using HTTP/2")
 
       val definitiveSettings =

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/PreviewServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/PreviewServerSettings.scala
@@ -24,8 +24,11 @@ import com.typesafe.config.Config
  * Options that are in "preview" or "early access" mode.
  * These options may change and/or be removed within patch releases
  * without early notice (e.g. by moving them into a stable supported place).
+ * 
+ * @deprecated PreviewServerSettings is deprecated, use pekko.http.scaladsl.settings.ServerSettings instead (since 2.0.0)
  */
 @ApiMayChange @DoNotInherit
+@deprecated("PreviewServerSettings is deprecated, use pekko.http.scaladsl.settings.ServerSettings instead", "2.0.0")
 abstract class PreviewServerSettings private[pekko] ()
     extends org.apache.pekko.http.javadsl.settings.PreviewServerSettings {
   self: PreviewServerSettingsImpl =>

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/settings/ServerSettings.scala
@@ -60,10 +60,19 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   def terminationDeadlineExceededResponse: HttpResponse
   def parsingErrorHandler: String
   def streamCancellationDelay: FiniteDuration
+  /**
+    * @since 2.0.0
+    */
+  def enableHttp2: Boolean
 
   /* Java APIs */
 
   override def getBacklog = this.backlog
+  /**
+    * @deprecated the preview server settings are now integrated into the main server settings (since 2.0.0)
+    */
+  @Deprecated
+  @deprecated("the preview server settings are now integrated into the main server settings", "2.0.0")
   override def getPreviewServerSettings: pekko.http.javadsl.settings.PreviewServerSettings = this.previewServerSettings
   override def getDefaultHostHeader = this.defaultHostHeader.asJava
   override def getPipeliningLimit = this.pipeliningLimit
@@ -87,6 +96,11 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   // ---
 
   // override for more specific return type
+  /**
+   * @deprecated the preview server settings are now integrated into the main server settings (since 2.0.0)
+   */
+  @Deprecated
+  @deprecated("the preview server settings are now integrated into the main server settings", "2.0.0")
   def withPreviewServerSettings(newValue: PreviewServerSettings): ServerSettings =
     self.copy(previewServerSettings = newValue)
   override def withMaxConnections(newValue: Int): ServerSettings = self.copy(maxConnections = newValue)
@@ -110,6 +124,7 @@ abstract class ServerSettings private[pekko] () extends pekko.http.javadsl.setti
   override def withParsingErrorHandler(newValue: String): ServerSettings = self.copy(parsingErrorHandler = newValue)
   override def withStreamCancellationDelay(newValue: FiniteDuration): ServerSettings =
     self.copy(streamCancellationDelay = newValue)
+  override def withEnableHttp2(newValue: Boolean): ServerSettings = self.copy(enableHttp2 = newValue)
 
   // overloads for Scala idiomatic use
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue)

--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/ClientServerSpec.scala
@@ -58,7 +58,7 @@ class ClientServerHttp2EnabledSpec extends ClientServerSpecBase(http2 = true)
 
 abstract class ClientServerSpecBase(http2: Boolean) extends PekkoSpecWithMaterializer(
       s"""
-     pekko.http.server.preview.enable-http2 = $http2
+     pekko.http.server.enable-http2 = $http2
      pekko.http.server.request-timeout = infinite
      pekko.http.server.log-unencrypted-network-bytes = 200
      pekko.http.client.log-unencrypted-network-bytes = 200

--- a/http2-tests/src/test/java/org/apache/pekko/http/javadsl/Http2JavaServerTest.java
+++ b/http2-tests/src/test/java/org/apache/pekko/http/javadsl/Http2JavaServerTest.java
@@ -35,7 +35,7 @@ public class Http2JavaServerTest {
                 + "pekko.actor.serialize-messages = off\n"
                 + "#pekko.actor.default-dispatcher.throughput = 1000\n"
                 + "pekko.actor.default-dispatcher.fork-join-executor.parallelism-max=8\n"
-                + "pekko.http.server.preview.enable-http2 = on\n");
+                + "pekko.http.server.enable-http2 = on\n");
     ActorSystem system = ActorSystem.create("ServerTest", testConf);
 
     Function<HttpRequest, CompletionStage<HttpResponse>> handler =

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -35,7 +35,7 @@ class H2SpecIntegrationSpec extends PekkoFreeSpec(
        loglevel = DEBUG
        loggers = ["org.apache.pekko.http.impl.util.SilenceAllTestEventListener"]
        http.server.log-unencrypted-network-bytes = 100
-       http.server.preview.enable-http2 = on
+       http.server.enable-http2 = on
        http.server.http2.log-frames = on
 
        actor.serialize-creators = off

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2cUpgradeSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/H2cUpgradeSpec.scala
@@ -27,7 +27,7 @@ import pekko.stream.scaladsl.{ Source, Tcp }
 import pekko.util.ByteString
 
 class H2cUpgradeSpec extends PekkoSpecWithMaterializer("""
-    pekko.http.server.preview.enable-http2 = on
+    pekko.http.server.enable-http2 = on
     pekko.http.server.http2.log-frames = on
   """) {
 

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -52,7 +52,7 @@ import org.scalatest.concurrent.ScalaFutures
 class Http2ClientServerSpec extends PekkoSpecWithMaterializer(
       """pekko.http.server.http2.log-frames = on
      pekko.http.server.log-unencrypted-network-bytes = 100
-     pekko.http.server.preview.enable-http2 = on
+     pekko.http.server.enable-http2 = on
      pekko.http.client.http2.log-frames = on
      pekko.http.client.log-unencrypted-network-bytes = 100
      pekko.actor.serialize-messages = false

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -62,7 +62,7 @@ abstract class Http2PersistentClientSpec(tls: Boolean) extends PekkoSpecWithMate
       // FIXME: would rather use remote-address-attribute, but that doesn't work with HTTP/2
       // see https://github.com/akka/akka-http/issues/3707
       """pekko.http.server.remote-address-attribute = on
-     pekko.http.server.preview.enable-http2 = on
+     pekko.http.server.enable-http2 = on
      pekko.http.client.http2.log-frames = on
      pekko.http.client.http2.max-persistent-attempts = 5
      pekko.http.client.log-unencrypted-network-bytes = 100

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpiSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/TelemetrySpiSpec.scala
@@ -68,7 +68,7 @@ class TelemetrySpiCypherSpec extends TelemetrySpiSpec(true)
 
 abstract class TelemetrySpiSpec(useTls: Boolean) extends PekkoSpecWithMaterializer(
       """
-     pekko.http.server.preview.enable-http2 = on
+     pekko.http.server.enable-http2 = on
      pekko.actor.serialize-messages = false
      pekko.http.http2-telemetry-class = "org.apache.pekko.http.impl.engine.http2.TestTelemetryImpl"
   """) with ScalaFutures with BeforeAndAfterAll {

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
@@ -27,7 +27,7 @@ import pekko.stream.scaladsl.Sink
 import pekko.util.ByteString
 
 class WithPriorKnowledgeSpec extends PekkoSpecWithMaterializer("""
-    pekko.http.server.preview.enable-http2 = on
+    pekko.http.server.enable-http2 = on
     pekko.http.server.http2.log-frames = on
   """) {
 

--- a/http2-tests/src/test/scala/org/apache/pekko/http/scaladsl/Http2ServerTest.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/scaladsl/Http2ServerTest.scala
@@ -44,7 +44,7 @@ object Http2ServerTest extends App {
     pekko.actor.serialize-messages = off
     #pekko.actor.default-dispatcher.throughput = 1000
     pekko.actor.default-dispatcher.fork-join-executor.parallelism-max=8
-    pekko.http.server.preview.enable-http2 = true
+    pekko.http.server.enable-http2 = true
                                                    """)
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
   implicit val ec: ExecutionContext = system.dispatcher


### PR DESCRIPTION
* WIP - needs tests
* aim would be to also backport this to 1.3.0