### PR TITLE
safe to create ByteString from array with no-copy

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/FrameEventRenderer.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/FrameEventRenderer.scala
@@ -129,6 +129,6 @@ private[http] final class FrameEventRenderer extends GraphStage[FlowShape[FrameE
       data(maskOffset + 3) = ((mask & 0x000000FF) >> 0).toByte
     }
 
-    ByteString(data)
+    ByteString.fromArrayUnsafe(data)
   }
 }


### PR DESCRIPTION
the array here is private to the method so we can avoid cloning it when we create the ByteString