### PR TITLE
remove remove sbt-hackers-digest

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.5")
-addSbtPlugin("net.virtual-void" % "sbt-hackers-digest" % "0.1.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 
 // used in ValidatePullRequest to check github PR comments whether to build all subprojects


### PR DESCRIPTION
* the failure in #822 is happening in sbt-hackers-digest and it's not really a core part of our build
* so, at least for now, it seems best to remove it till we can get to the bottom of why it fails
* #823 didn't fix the build