### PR TITLE
add warnings about limitations of idle-timeout

### DIFF
--- a/docs/src/main/paradox/common/timeouts.md
+++ b/docs/src/main/paradox/common/timeouts.md
@@ -15,6 +15,15 @@ on a connection for over `idle-timeout` time, the connection will be automatical
 This setting should be used as a last-resort safeguard to prevent unused or stuck connections from consuming resources for
 an indefinite time.
 
+This is a bidirectional inactivity timeout. It triggers only when no
+bytes are sent or received for the configured duration. Traffic in
+either direction, including a client sending bytes at intervals shorter
+than the timeout, keeps the connection alive; it is not an overall
+request-receive timeout. Lowering this value and configuring
+`pekko.http.server.parsing.max-content-length` reduce exposure but do not
+bound request duration. Use an appropriately configured reverse proxy or
+application-level entity timeout when a hard receive deadline is required.
+
 The setting works the same way for server and client connections and it is configurable independently using the following keys:
 
 ```

--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -45,6 +45,11 @@ pekko.http {
 
     # The time after which an idle connection will be automatically closed.
     # Set to `infinite` to completely disable idle connection timeouts.
+    #
+    # Note: this timeout only triggers when no data is received. A slow
+    # client that sends data continuously (even at a low rate) will keep
+    # the connection alive. For untrusted clients, consider a lower value
+    # and use max-content-length to bound total entity size.
     idle-timeout = 60 s
 
     # Defines the default time period within which the application has to

--- a/http-core/src/main/resources/reference.conf
+++ b/http-core/src/main/resources/reference.conf
@@ -46,10 +46,14 @@ pekko.http {
     # The time after which an idle connection will be automatically closed.
     # Set to `infinite` to completely disable idle connection timeouts.
     #
-    # Note: this timeout only triggers when no data is received. A slow
-    # client that sends data continuously (even at a low rate) will keep
-    # the connection alive. For untrusted clients, consider a lower value
-    # and use max-content-length to bound total entity size.
+    # Note: This is a bidirectional inactivity timeout. It triggers only when
+    # no bytes are sent or received for the configured duration. Traffic in
+    # either direction, including a client sending bytes at intervals shorter
+    # than the timeout, keeps the connection alive; it is not an overall
+    # request-receive timeout. Lowering this value and configuring
+    # pekko.http.server.parsing.max-content-length reduce exposure but do not
+    # bound request duration. Use an appropriately configured reverse proxy or
+    # application-level entity timeout when a hard receive deadline is required.
     idle-timeout = 60 s
 
     # Defines the default time period within which the application has to


### PR DESCRIPTION
The idle-timeout does catch completely idle connections, but an attacker sending one byte per second would keep the connection alive indefinitely since data is flowing. The request timeout only starts after the entity is complete.

The real mitigations users can apply:
- Lower idle-timeout for untrusted clients
- Use max-content-length to bound total entity size
- Add a reverse proxy (nginx, etc.) that has its own slowloris protections

Adding a per-entity receive timeout to the framework would be a significant feature.