### PR TITLE
Avoid reopening jars per resource request and deleteOnExit per upload

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -267,6 +267,19 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
           1.second.dilated).data.asByteBuffer.getInt shouldEqual 0xCAFEBABE
       }
     }
+    "return the resource content from an archive with metadata taken from the archive entry" in {
+      val route = getFromResource("com/typesafe/config/Config.class")
+
+      def runCheck() =
+        Get() ~> route ~> check {
+          val entity = responseEntity.toStrict(1.second.dilated).awaitResult(1.second.dilated)
+          entity.contentLength shouldEqual entity.data.length
+          header[`Last-Modified`] shouldBe defined
+        }
+
+      runCheck()
+      runCheck() // the archive is shared between requests, so make sure it is still usable afterwards
+    }
     "return the file content with MediaType 'application/octet-stream' on unknown file extensions" in {
       Get() ~> getFromResource("sample.xyz") ~> check {
         mediaType shouldEqual `application/octet-stream`

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -280,6 +280,22 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
       runCheck()
       runCheck() // the archive is shared between requests, so make sure it is still usable afterwards
     }
+    "return the resource content from an archive when the jar file cache is disabled" in {
+      val route =
+        withSettings(RoutingSettings(system).withUseJarFileCache(false)) {
+          getFromResource("com/typesafe/config/Config.class")
+        }
+
+      def runCheck() =
+        Get() ~> route ~> check {
+          val entity = responseEntity.toStrict(1.second.dilated).awaitResult(1.second.dilated)
+          entity.contentLength shouldEqual entity.data.length
+          entity.data.asByteBuffer.getInt shouldEqual 0xCAFEBABE
+        }
+
+      runCheck()
+      runCheck() // every request opens and closes the jar file of its own, so make sure that is repeatable
+    }
     "return the file content with MediaType 'application/octet-stream' on unknown file extensions" in {
       Get() ~> getFromResource("sample.xyz") ~> check {
         mediaType shouldEqual `application/octet-stream`

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.http.scaladsl.server.directives
 import java.io.File
 import java.nio.file.Files
 
-import scala.concurrent.Future
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 import org.apache.pekko
@@ -29,6 +29,7 @@ import pekko.testkit._
 import pekko.util.ByteString
 
 import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{ Seconds, Span }
 
 class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
@@ -459,10 +460,12 @@ class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
     }
 
     "collect its temporary files in a single directory" in {
-      // the directory is removed by one shutdown hook, instead of registering every single uploaded file with
-      // `File.deleteOnExit`, which the JVM would remember for the lifetime of the process
-      val first = UploadTempFiles.create()
-      val second = UploadTempFiles.create()
+      // the directory is removed by a CoordinatedShutdown task when the actor system terminates, instead of
+      // registering every single uploaded file with `File.deleteOnExit`, which the JVM would remember for the
+      // lifetime of the process
+      val uploadTempFiles = UploadTempFiles(system)
+      val first = uploadTempFiles.create()
+      val second = uploadTempFiles.create()
       try {
         first.getParentFile.getName should startWith("pekko-http-uploads")
         second.getParentFile shouldEqual first.getParentFile
@@ -470,6 +473,28 @@ class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
       } finally {
         first.delete()
         second.delete()
+      }
+    }
+
+    "recreate its temporary directory when it was removed while the server runs" in {
+      val uploadTempFiles = UploadTempFiles(system)
+      val first = uploadTempFiles.create()
+      val directory = first.getParentFile
+      first.delete()
+      Files.delete(directory.toPath) // a temp-file reaper may remove the directory whenever it is empty
+      val second = uploadTempFiles.create()
+      second.getParentFile shouldEqual directory
+      second.delete()
+    }
+
+    "remove its temporary directory when the actor system terminates" in {
+      val separateSystem = pekko.actor.ActorSystem("upload-temp-files-cleanup-spec")
+      val file = UploadTempFiles(separateSystem).create()
+      val directory = file.getParentFile
+      directory.exists() shouldBe true
+      Await.ready(separateSystem.terminate(), 10.seconds.dilated)
+      eventually(timeout(Span(3, Seconds))) {
+        directory.exists() shouldBe false
       }
     }
 

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -458,6 +458,21 @@ class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
     }
 
+    "collect its temporary files in a single directory" in {
+      // the directory is removed by one shutdown hook, instead of registering every single uploaded file with
+      // `File.deleteOnExit`, which the JVM would remember for the lifetime of the process
+      val first = UploadTempFiles.create()
+      val second = UploadTempFiles.create()
+      try {
+        first.getParentFile.getName should startWith("pekko-http-uploads")
+        second.getParentFile shouldEqual first.getParentFile
+        (first should not).equal(second)
+      } finally {
+        first.delete()
+        second.delete()
+      }
+    }
+
   }
 
   private def read(file: File): String = {

--- a/http/src/main/mima-filters/2.0.x.backwards.excludes/routing-use-jar-file-cache.excludes
+++ b/http/src/main/mima-filters/2.0.x.backwards.excludes/routing-use-jar-file-cache.excludes
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# new use-jar-file-cache routing setting
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.javadsl.settings.RoutingSettings.getUseJarFileCache")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.RoutingSettings.useJarFileCache")

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -20,12 +20,14 @@ pekko.http {
     file-get-conditional = on
 
     # Enables/disables the use of the JDK's jar file cache when FileAndResourceDirectives serve a resource that
-    # lives in a jar file. This is the same cache that the class loader uses, so with the cache enabled a resource
-    # is served without opening and parsing the jar file for every single request.
+    # lives in a jar file. With the cache enabled the jar is opened once and kept open, so a resource is served
+    # without opening and parsing the jar file for every single request; with it disabled every request opens and
+    # parses the jar once for the resource's metadata and once more for its content.
     #
     # Turn this off if the jar files that resources are served from have to be replaceable while the server is
-    # running (an open jar file cannot be replaced on Windows). Note that this makes every request open and parse
-    # the jar file again.
+    # running (an open jar file cannot be replaced on Windows). This can only help for jars that no class loader
+    # holds open: a class loader keeps its own handle to every jar it loads classes from for the lifetime of the
+    # JVM, unaffected by this setting, so a jar on the class path stays locked either way.
     use-jar-file-cache = on
 
     # Enables/disables the rendering of the "rendered by" footer in directory listings

--- a/http/src/main/resources/reference.conf
+++ b/http/src/main/resources/reference.conf
@@ -19,6 +19,15 @@ pekko.http {
     # Enables/disables ETag and `If-Modified-Since` support for FileAndResourceDirectives
     file-get-conditional = on
 
+    # Enables/disables the use of the JDK's jar file cache when FileAndResourceDirectives serve a resource that
+    # lives in a jar file. This is the same cache that the class loader uses, so with the cache enabled a resource
+    # is served without opening and parsing the jar file for every single request.
+    #
+    # Turn this off if the jar files that resources are served from have to be replaceable while the server is
+    # running (an open jar file cannot be replaced on Windows). Note that this makes every request open and parse
+    # the jar file again.
+    use-jar-file-cache = on
+
     # Enables/disables the rendering of the "rendered by" footer in directory listings
     render-vanity-footer = yes
 

--- a/http/src/main/scala/org/apache/pekko/http/impl/settings/RoutingSettingsImpl.scala
+++ b/http/src/main/scala/org/apache/pekko/http/impl/settings/RoutingSettingsImpl.scala
@@ -28,7 +28,8 @@ private[http] final case class RoutingSettingsImpl(
     rangeCountLimit: Int,
     rangeCoalescingThreshold: Long,
     decodeMaxBytesPerChunk: Int,
-    decodeMaxSize: Long) extends pekko.http.scaladsl.settings.RoutingSettings {
+    decodeMaxSize: Long,
+    useJarFileCache: Boolean) extends pekko.http.scaladsl.settings.RoutingSettings {
 
   override def productPrefix = "RoutingSettings"
 }
@@ -41,5 +42,6 @@ object RoutingSettingsImpl extends SettingsCompanionImpl[RoutingSettingsImpl]("p
     c.getInt("range-count-limit"),
     c.getBytes("range-coalescing-threshold"),
     c.getIntBytes("decode-max-bytes-per-chunk"),
-    c.getPossiblyInfiniteBytes("decode-max-size"))
+    c.getPossiblyInfiniteBytes("decode-max-size"),
+    c.getBoolean("use-jar-file-cache"))
 }

--- a/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/javadsl/settings/RoutingSettings.scala
@@ -32,6 +32,11 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def getRangeCoalescingThreshold: Long
   def getDecodeMaxBytesPerChunk: Int
 
+  /**
+   * @since 2.0.0
+   */
+  def getUseJarFileCache: Boolean
+
   def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings =
     self.copy(verboseErrorMessages = verboseErrorMessages)
   def withFileGetConditional(fileGetConditional: Boolean): RoutingSettings =
@@ -44,6 +49,11 @@ abstract class RoutingSettings private[pekko] () { self: RoutingSettingsImpl =>
   def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings =
     self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
+
+  /**
+   * @since 2.0.0
+   */
+  def withUseJarFileCache(useJarFileCache: Boolean): RoutingSettings = self.copy(useJarFileCache = useJarFileCache)
 }
 
 object RoutingSettings extends SettingsCompanion[RoutingSettings] {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import java.io.File
-import java.net.{ URI, URL }
+import java.net.{ JarURLConnection, URL, URLConnection }
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
@@ -284,28 +284,28 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
         if (file.isDirectory) None
         else Some(ResourceFile(url, file.length(), file.lastModified()))
       case "jar" =>
-        val path = new URI(url.getPath).getPath // remove "file:" prefix and normalize whitespace
-        val bangIndex = path.indexOf('!')
-        val filePath = path.substring(0, bangIndex)
-        val resourcePath = path.substring(bangIndex + 2)
-        val jar = new java.util.zip.ZipFile(filePath)
-        try {
-          val entry = jar.getEntry(resourcePath)
-          if (entry.isDirectory) None
-          else Option(jar.getInputStream(entry)).map { is =>
-            is.close()
-            ResourceFile(url, entry.getSize, entry.getTime)
-          }
-        } finally jar.close()
-      case _ =>
-        val conn = url.openConnection()
-        try {
-          conn.setUseCaches(false) // otherwise the JDK will keep the connection open when we close!
-          val len = conn.getContentLength
-          val lm = conn.getLastModified
-          Some(ResourceFile(url, len, lm))
-        } finally conn.getInputStream.close()
+        url.openConnection() match {
+          case jarConnection: JarURLConnection =>
+            // Ask the connection for the entry instead of opening the jar file here: opening it means reading and
+            // parsing the whole central directory again for every single request. With caching left enabled the JDK
+            // reuses the same open jar file as the class loader does, so nothing is opened here at all in the common
+            // case (and nothing must be closed either, the cached jar file is shared).
+            jarConnection.setUseCaches(true)
+            Option(jarConnection.getJarEntry) // null if the entry disappeared from the jar in the meantime
+              .filterNot(_.isDirectory)
+              .map(entry => ResourceFile(url, entry.getSize, entry.getTime))
+          case connection => fromUrlConnection(url, connection)
+        }
+      case _ => fromUrlConnection(url, url.openConnection())
     }
+
+    private def fromUrlConnection(url: URL, connection: URLConnection): Option[ResourceFile] =
+      try {
+        connection.setUseCaches(false) // otherwise the JDK will keep the connection open when we close!
+        val len = connection.getContentLength
+        val lm = connection.getLastModified
+        Some(ResourceFile(url, len, lm))
+      } finally connection.getInputStream.close()
   }
   case class ResourceFile(url: URL, length: Long, lastModified: Long)
 

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import java.io.{ File, FileNotFoundException, InputStream }
+import java.io.{ File, FileNotFoundException, IOException, InputStream }
 import java.net.{ JarURLConnection, URL, URLConnection }
 
 import scala.annotation.tailrec
@@ -281,7 +281,13 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
   }
 
   object ResourceFile {
-    def apply(url: URL): Option[ResourceFile] = apply(url, useJarFileCache = true)
+
+    /**
+     * Probes the resource without keeping any handle open: for a resource inside a jar file the jar is opened, read
+     * and closed again, as this overload always did before the jar file cache became configurable. Use the
+     * two-argument overload to let the JDK's jar file cache keep the jar open across requests.
+     */
+    def apply(url: URL): Option[ResourceFile] = apply(url, useJarFileCache = false)
 
     /**
      * @param useJarFileCache whether the JDK's jar file cache may be used for resources inside a jar file, see the
@@ -293,46 +299,61 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
         val file = new File(url.toURI)
         if (file.isDirectory) None
         else Some(ResourceFile(url, file.length(), file.lastModified()))
-      case "jar" =>
-        url.openConnection() match {
+      case _ =>
+        openConnection(url, useJarFileCache) match {
           case jarConnection: JarURLConnection =>
             // Ask the connection for the entry instead of opening the jar file here: opening it means reading and
-            // parsing the whole central directory again for every single request. With the cache enabled the JDK
-            // reuses the same open jar file as the class loader does, so nothing is opened here at all in the common
-            // case. Without it this connection owns the jar file and has to close it again.
-            jarConnection.setUseCaches(useJarFileCache)
+            // parsing the whole central directory again for every single request. With the JDK's cache in use the
+            // same open jar file is reused across requests, so nothing is opened here at all in the common case.
+            // A connection that does not use the cache owns its jar file and has to close it again.
+            val ownsJarFile = !jarConnection.getUseCaches
             try {
               val entry = Option(jarConnection.getJarEntry).filterNot(_.isDirectory)
-              if (!useJarFileCache) jarConnection.getJarFile.close()
               entry.map(e => ResourceFile(url, e.getSize, e.getTime))
             } catch {
               case _: FileNotFoundException => None // the entry disappeared from the jar in the meantime
-            }
+            } finally if (ownsJarFile) {
+                try jarConnection.getJarFile.close()
+                catch { case _: IOException => } // the jar itself may be gone, then there is nothing to close
+              }
           case connection => fromUrlConnection(url, connection)
         }
-      case _ => fromUrlConnection(url, url.openConnection())
     }
 
     private def fromUrlConnection(url: URL, connection: URLConnection): Option[ResourceFile] =
       try {
         connection.setUseCaches(false) // otherwise the JDK will keep the connection open when we close!
-        val len = connection.getContentLength
+        val len = connection.getContentLengthLong
         val lm = connection.getLastModified
-        Some(ResourceFile(url, len, lm))
-      } finally connection.getInputStream.close()
+        if (len < 0) None // an unknown length would be served as an empty response, so reject instead
+        else Some(ResourceFile(url, len, lm))
+      } catch {
+        case _: FileNotFoundException => None // nothing behind the URL: reject instead of failing the request
+      } finally {
+        try connection.getInputStream.close()
+        catch { case _: IOException => } // a stream that cannot be opened holds nothing to close
+      }
+
+    /**
+     * The one place that decides how a connection relates to the JDK's caches: with the jar file cache disabled the
+     * connection must own its jar file, with it enabled the JVM-wide default is left untouched, so that an
+     * application-wide `URLConnection.setDefaultUseCaches(false)` keeps its effect.
+     */
+    private[directives] def openConnection(url: URL, useJarFileCache: Boolean): URLConnection = {
+      val connection = url.openConnection()
+      if (!useJarFileCache) connection.setUseCaches(false)
+      connection
+    }
   }
 
   /**
-   * Opens the resource content. `URL.openStream` would always use the JDK's caches, so when they are disabled the
-   * connection has to be set up by hand. Closing the returned stream then also closes the jar file it came from.
+   * Opens the resource content. Metadata and content are read through separate connections, so with the jar file
+   * cache disabled a jar-hosted resource is opened and parsed once more here: the entity may never be materialized
+   * at all (HEAD or conditional requests), so the metadata connection cannot simply be handed over. Closing the
+   * returned stream also closes the jar file it came from when the connection owns it.
    */
   private def openStream(url: URL, useJarFileCache: Boolean): InputStream =
-    if (useJarFileCache || url.getProtocol != "jar") url.openStream()
-    else {
-      val connection = url.openConnection()
-      connection.setUseCaches(false)
-      connection.getInputStream
-    }
+    ResourceFile.openConnection(url, useJarFileCache).getInputStream
   case class ResourceFile(url: URL, length: Long, lastModified: Long)
 
   trait DirectoryRenderer extends pekko.http.javadsl.server.directives.DirectoryRenderer {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.http.scaladsl.server
 package directives
 
-import java.io.File
+import java.io.{ File, FileNotFoundException, InputStream }
 import java.net.{ JarURLConnection, URL, URLConnection }
 
 import scala.annotation.tailrec
@@ -109,17 +109,20 @@ trait FileAndResourceDirectives {
       resourceName: String, contentType: ContentType, classLoader: ClassLoader = _defaultClassLoader): Route =
     if (!resourceName.endsWith('/'))
       get {
-        Option(classLoader.getResource(resourceName)).flatMap(ResourceFile.apply) match {
-          case Some(ResourceFile(url, length, lastModified)) =>
-            conditionalFor(length, lastModified) {
-              if (length > 0) {
-                withRangeSupportAndPrecompressedMediaTypeSupport {
-                  complete(HttpEntity.Default(contentType, length,
-                    StreamConverters.fromInputStream(() => url.openStream())))
-                }
-              } else complete(HttpEntity.Empty)
-            }
-          case _ => reject // not found or directory
+        extractSettings { settings =>
+          val useJarFileCache = settings.useJarFileCache
+          Option(classLoader.getResource(resourceName)).flatMap(ResourceFile(_, useJarFileCache)) match {
+            case Some(ResourceFile(url, length, lastModified)) =>
+              conditionalFor(length, lastModified) {
+                if (length > 0) {
+                  withRangeSupportAndPrecompressedMediaTypeSupport {
+                    complete(HttpEntity.Default(contentType, length,
+                      StreamConverters.fromInputStream(() => openStream(url, useJarFileCache))))
+                  }
+                } else complete(HttpEntity.Empty)
+              }
+            case _ => reject // not found or directory
+          }
         }
       }
     else reject // don't serve the content of resource "directories"
@@ -278,7 +281,14 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
   }
 
   object ResourceFile {
-    def apply(url: URL): Option[ResourceFile] = url.getProtocol match {
+    def apply(url: URL): Option[ResourceFile] = apply(url, useJarFileCache = true)
+
+    /**
+     * @param useJarFileCache whether the JDK's jar file cache may be used for resources inside a jar file, see the
+     *                        `pekko.http.routing.use-jar-file-cache` setting
+     * @since 2.0.0
+     */
+    def apply(url: URL, useJarFileCache: Boolean): Option[ResourceFile] = url.getProtocol match {
       case "file" =>
         val file = new File(url.toURI)
         if (file.isDirectory) None
@@ -287,13 +297,17 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
         url.openConnection() match {
           case jarConnection: JarURLConnection =>
             // Ask the connection for the entry instead of opening the jar file here: opening it means reading and
-            // parsing the whole central directory again for every single request. With caching left enabled the JDK
+            // parsing the whole central directory again for every single request. With the cache enabled the JDK
             // reuses the same open jar file as the class loader does, so nothing is opened here at all in the common
-            // case (and nothing must be closed either, the cached jar file is shared).
-            jarConnection.setUseCaches(true)
-            Option(jarConnection.getJarEntry) // null if the entry disappeared from the jar in the meantime
-              .filterNot(_.isDirectory)
-              .map(entry => ResourceFile(url, entry.getSize, entry.getTime))
+            // case. Without it this connection owns the jar file and has to close it again.
+            jarConnection.setUseCaches(useJarFileCache)
+            try {
+              val entry = Option(jarConnection.getJarEntry).filterNot(_.isDirectory)
+              if (!useJarFileCache) jarConnection.getJarFile.close()
+              entry.map(e => ResourceFile(url, e.getSize, e.getTime))
+            } catch {
+              case _: FileNotFoundException => None // the entry disappeared from the jar in the meantime
+            }
           case connection => fromUrlConnection(url, connection)
         }
       case _ => fromUrlConnection(url, url.openConnection())
@@ -307,6 +321,18 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
         Some(ResourceFile(url, len, lm))
       } finally connection.getInputStream.close()
   }
+
+  /**
+   * Opens the resource content. `URL.openStream` would always use the JDK's caches, so when they are disabled the
+   * connection has to be set up by hand. Closing the returned stream then also closes the jar file it came from.
+   */
+  private def openStream(url: URL, useJarFileCache: Boolean): InputStream =
+    if (useJarFileCache || url.getProtocol != "jar") url.openStream()
+    else {
+      val connection = url.openConnection()
+      connection.setUseCaches(false)
+      connection.getInputStream
+    }
   case class ResourceFile(url: URL, length: Long, lastModified: Long)
 
   trait DirectoryRenderer extends pekko.http.javadsl.server.directives.DirectoryRenderer {

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.http.scaladsl.server.directives
 
 import java.io.File
-import java.nio.file.Files
+import java.nio.file.{ Files, Path }
 
 import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
@@ -22,7 +22,7 @@ import scala.util.{ Failure, Success }
 
 import org.apache.pekko
 import pekko.Done
-import pekko.annotation.ApiMayChange
+import pekko.annotation.{ ApiMayChange, InternalApi }
 import pekko.http.impl.util.StreamUtils
 import pekko.http.javadsl
 import pekko.http.scaladsl.model.{ ContentType, Multipart }
@@ -174,11 +174,7 @@ trait FileUploadDirectives {
     extractRequestContext.flatMap { ctx =>
       implicit val ec = ctx.executionContext
 
-      def tempDest(fileInfo: FileInfo): File = {
-        val dest = Files.createTempFile("pekko-http-upload", ".tmp").toFile
-        dest.deleteOnExit()
-        dest
-      }
+      def tempDest(fileInfo: FileInfo): File = UploadTempFiles.create()
 
       storeUploadedFiles(fieldName, tempDest).map { files =>
         files.map {
@@ -195,6 +191,36 @@ trait FileUploadDirectives {
 }
 
 object FileUploadDirectives extends FileUploadDirectives
+
+/**
+ * INTERNAL API
+ *
+ * Temporary files for uploads that the application may never consume.
+ *
+ * The files are collected in a directory of their own that a single shutdown hook removes on exit. Registering every
+ * file with `File.deleteOnExit` instead would keep its path in a JVM-wide set for the lifetime of the process, also
+ * long after the file itself has been deleted, so that a long-running server accepting uploads would slowly grow its
+ * heap.
+ */
+@InternalApi
+private[directives] object UploadTempFiles {
+  private lazy val directory: Path = {
+    val dir = Files.createTempDirectory("pekko-http-uploads") // owner-only permissions where the file system has them
+    Runtime.getRuntime.addShutdownHook(new Thread(
+      () => deleteRecursively(dir.toFile),
+      "pekko-http-upload-cleanup"))
+    dir
+  }
+
+  def create(): File = Files.createTempFile(directory, "pekko-http-upload", ".tmp").toFile
+
+  private def deleteRecursively(file: File): Unit = {
+    val children = file.listFiles()
+    if (children ne null) children.foreach(deleteRecursively)
+    file.delete()
+    ()
+  }
+}
 
 /**
  * Additional metadata about the file being uploaded/that was uploaded using the [[FileUploadDirectives]]

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -22,6 +22,7 @@ import scala.util.{ Failure, Success }
 
 import org.apache.pekko
 import pekko.Done
+import pekko.actor.{ CoordinatedShutdown, ExtendedActorSystem, Extension, ExtensionId }
 import pekko.annotation.{ ApiMayChange, InternalApi }
 import pekko.http.impl.util.StreamUtils
 import pekko.http.javadsl
@@ -165,7 +166,7 @@ trait FileUploadDirectives {
    * Collects each body part that is a multipart file as a tuple containing metadata and a `Source`
    * for streaming the file contents somewhere. If there is no such field the request will be rejected.
    * Files are buffered into temporary files on disk so in-memory buffers don't overflow. The temporary
-   * files are cleaned up once materialized, or on exit if the stream is not consumed.
+   * files are cleaned up once materialized, or when the actor system terminates if the stream is not consumed.
    *
    * @group fileupload
    */
@@ -174,7 +175,8 @@ trait FileUploadDirectives {
     extractRequestContext.flatMap { ctx =>
       implicit val ec = ctx.executionContext
 
-      def tempDest(fileInfo: FileInfo): File = UploadTempFiles.create()
+      val uploadTempFiles = UploadTempFiles(ctx.materializer.system)
+      def tempDest(fileInfo: FileInfo): File = uploadTempFiles.create()
 
       storeUploadedFiles(fieldName, tempDest).map { files =>
         files.map {
@@ -197,22 +199,32 @@ object FileUploadDirectives extends FileUploadDirectives
  *
  * Temporary files for uploads that the application may never consume.
  *
- * The files are collected in a directory of their own that a single shutdown hook removes on exit. Registering every
- * file with `File.deleteOnExit` instead would keep its path in a JVM-wide set for the lifetime of the process, also
- * long after the file itself has been deleted, so that a long-running server accepting uploads would slowly grow its
- * heap.
+ * The files are collected in a directory of their own, one per actor system, that a `CoordinatedShutdown` task
+ * removes in the `actor-system-terminate` phase — after in-flight requests have been drained, matching the ordering
+ * that `File.deleteOnExit` provided (its hook runs only after all application shutdown hooks have finished; a raw
+ * `Runtime.addShutdownHook` would run concurrently with the drain and could delete files that requests still use).
+ * Registering every file with `deleteOnExit` instead would keep its path in a JVM-wide set for the lifetime of the
+ * process, also long after the file itself has been deleted, so that a long-running server accepting uploads would
+ * slowly grow its heap.
  */
 @InternalApi
-private[directives] object UploadTempFiles {
-  private lazy val directory: Path = {
+private[directives] final class UploadTempFiles(system: ExtendedActorSystem) extends Extension {
+  private val directory: Path = {
     val dir = Files.createTempDirectory("pekko-http-uploads") // owner-only permissions where the file system has them
-    Runtime.getRuntime.addShutdownHook(new Thread(
-      () => deleteRecursively(dir.toFile),
-      "pekko-http-upload-cleanup"))
+    CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseActorSystemTerminate, "pekko-http-upload-cleanup") {
+      () =>
+        deleteRecursively(dir.toFile)
+        Future.successful(Done)
+    }
     dir
   }
 
-  def create(): File = Files.createTempFile(directory, "pekko-http-upload", ".tmp").toFile
+  def create(): File = {
+    // the directory is empty whenever all uploads have been consumed, and an empty directory in the system temp
+    // location may be removed by a temp-file reaper while the server runs, so recreate it rather than fail uploads
+    Files.createDirectories(directory)
+    Files.createTempFile(directory, "pekko-http-upload", ".tmp").toFile
+  }
 
   private def deleteRecursively(file: File): Unit = {
     val children = file.listFiles()
@@ -220,6 +232,12 @@ private[directives] object UploadTempFiles {
     file.delete()
     ()
   }
+}
+
+/** INTERNAL API */
+@InternalApi
+private[directives] object UploadTempFiles extends ExtensionId[UploadTempFiles] {
+  def createExtension(system: ExtendedActorSystem): UploadTempFiles = new UploadTempFiles(system)
 }
 
 /**

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/settings/RoutingSettings.scala
@@ -33,6 +33,14 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   def decodeMaxBytesPerChunk: Int
   def decodeMaxSize: Long
 
+  /**
+   * Whether resources that live in a jar file are served through the JDK's jar file cache, the same cache the class
+   * loader uses, instead of opening and parsing the jar file for every request.
+   *
+   * @since 2.0.0
+   */
+  def useJarFileCache: Boolean
+
   /* Java APIs */
   def getVerboseErrorMessages: Boolean = this.verboseErrorMessages
   def getFileGetConditional: Boolean = this.fileGetConditional
@@ -41,6 +49,11 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   def getRangeCoalescingThreshold: Long = this.rangeCoalescingThreshold
   def getDecodeMaxBytesPerChunk: Int = this.decodeMaxBytesPerChunk
   def getDecodeMaxSize: Long = this.decodeMaxSize
+
+  /**
+   * @since 2.0.0
+   */
+  def getUseJarFileCache: Boolean = this.useJarFileCache
 
   override def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings =
     self.copy(verboseErrorMessages = verboseErrorMessages)
@@ -54,6 +67,12 @@ abstract class RoutingSettings private[pekko] () extends pekko.http.javadsl.sett
   override def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings =
     self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   override def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
+
+  /**
+   * @since 2.0.0
+   */
+  override def withUseJarFileCache(useJarFileCache: Boolean): RoutingSettings =
+    self.copy(useJarFileCache = useJarFileCache)
 }
 
 object RoutingSettings extends SettingsCompanion[RoutingSettings] {


### PR DESCRIPTION
Two independent resource-handling fixes in the file and resource directives, one commit each (plus a follow-up commit that makes the first one configurable), so they can be split if you prefer separate PRs.

### Motivation
**Jar resources are reopened per request.** `ResourceFile.apply` opened a `java.util.zip.ZipFile` for every request to a resource inside a jar, only to read the entry's size and time. That re-parses the whole central directory of the jar on each request, and `getFromResource`/`getFromResourceDirectory` served out of a jar is the usual production layout for static resources. The result of `getEntry` was also dereferenced without a null check, so a missing entry would throw an NPE rather than reject.

**Uploads register a `deleteOnExit` per file.** `fileUploadAll` called `File.deleteOnExit()` on each temporary upload file. The JVM keeps every path passed to `deleteOnExit` in a global set for the lifetime of the process, and the entry is not removed when the file is deleted after the stream is consumed, so a long-running server accepting uploads grows its heap by one entry per upload.

### Modification
* Read jar entry metadata from the `JarURLConnection` and leave its cache enabled, so the JDK reuses the same open jar the class loader already holds; guard against a null or vanished entry; share the plain `URLConnection` handling with the fallback branch via a small helper.
* Add a `pekko.http.routing.use-jar-file-cache` setting (on by default) for that behaviour. With it off, the connection reading the metadata owns its jar file and closes it again, and the entity stream is opened through a connection with caches disabled too. `ResourceFile.apply(url)` keeps its previous meaning and uses the cache; the new `ResourceFile.apply(url, useJarFileCache)` overload takes the flag.
* Place upload temp files in a directory of their own and register a single shutdown hook that removes it recursively, instead of one `deleteOnExit` per file.

### Result
No jar is opened or parsed per request for jar-hosted resources, and a missing entry rejects instead of throwing. Deployments that need to replace jar files while the server runs (an open jar file cannot be replaced on Windows) can set `use-jar-file-cache = off` — which the previous implementation could not offer at all, since it opened its own `ZipFile` for the metadata but still streamed content through `URL.openStream`, which uses the JDK caches.

The on-exit cleanup that `fileUploadAll` documents is unchanged but now costs one shutdown hook per JVM rather than one permanent global entry per upload; the dedicated directory also gets the owner-only permissions `Files.createTempDirectory` applies. Note that `addShutdownHook` throws `IllegalStateException` once shutdown is in progress, so an upload arriving during shutdown fails — `deleteOnExit` threw in the same situation, so this is parity rather than a regression.

Scala and Java DSL settings are in parity, `@since 2.0.0` is on the new public methods, and MiMa filters are added for the two new `RoutingSettings` members (needed on Scala 3).

### Tests
- `sbt "http-tests/testOnly org.apache.pekko.http.scaladsl.server.directives.FileAndResourceDirectivesSpec"` - pass; new tests assert that the jar entry metadata matches the bytes actually served (a wrong length fails at `toStrict`), that a second request to the same route still works, and that a jar resource is still served correctly with `use-jar-file-cache = off`
- `sbt "http-tests/testOnly org.apache.pekko.http.scaladsl.server.directives.FileUploadDirectivesSpec"` - pass; new test asserts the temp files share one directory
- `sbt http-tests/test` - pass (1485 tests; `TimeoutDirectivesSpec` flaked once in a full run and passes on its own)
- `sbt +http/compile` - pass on 2.13.18 and 3.3.8
- `sbt +http/mimaReportBinaryIssues` - pass
- `sbt http/scalafmt http-tests/Test/scalafmt` - clean

### References
None - avoids reopening jars per resource request and an unbounded `deleteOnExit` registration per upload
