### PR TITLE
Compare path elements when checking that a served file is below the base directory

### DIFF
--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -195,6 +195,18 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
       shouldReject("..%c0%af", warnings = 0)
       shouldReject("..%c1%9c", warnings = 0)
     }
+    "reject requests whose path can never name a file" in {
+      // a percent-encoded NUL decodes into the path segment, but no file-system path may contain it, so
+      // canonicalization throws; that must surface as a rejection, not as an error escaping to the exception handler
+      def route(uri: String) =
+        mapRequestContext(_.withUnmatchedPath(Path("/" + uri))) { _getFromDirectory("someDir") }
+
+      EventFilter.warning(pattern = ".* points to a location that is not part of .*", occurrences = 1).intercept {
+        Get() ~> route("na%00ive.txt") ~> check {
+          handled shouldEqual false
+        }
+      }
+    }
     "return the file content with the MediaType matching the file extension" in {
       Get("fileA.txt") ~> _getFromDirectory("someDir") ~> check {
         mediaType shouldEqual `text/plain`

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
 
 import scala.concurrent.duration._
@@ -46,7 +45,7 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
   val siblingDir = new File(tempDir.toFile, "dirWithLink-private")
   siblingDir.mkdir()
   val siblingFile = new File(siblingDir, "secret.txt")
-  Files.write(siblingFile.toPath, "secret".getBytes(StandardCharsets.UTF_8))
+  Files.createFile(siblingFile.toPath)
   val siblingSymlink = Files.createSymbolicLink(
     Paths.get(dirWithLink.getAbsolutePath, "linked-sibling"),
     siblingDir.toPath.toAbsolutePath)

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectivesSymlinkSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.http.scaladsl.server
 package directives
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
 
 import scala.concurrent.duration._
@@ -41,9 +42,21 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
     Paths.get(dirWithLink.getAbsolutePath, "linked-dir"),
     new File(testRoot, "subDirectory").toPath.toAbsolutePath)
 
+  // a sibling of the served directory whose name has the name of the served directory as a prefix
+  val siblingDir = new File(tempDir.toFile, "dirWithLink-private")
+  siblingDir.mkdir()
+  val siblingFile = new File(siblingDir, "secret.txt")
+  Files.write(siblingFile.toPath, "secret".getBytes(StandardCharsets.UTF_8))
+  val siblingSymlink = Files.createSymbolicLink(
+    Paths.get(dirWithLink.getAbsolutePath, "linked-sibling"),
+    siblingDir.toPath.toAbsolutePath)
+
   override def afterAll(): Unit = {
     super.afterAll()
     Files.deleteIfExists(symlink)
+    Files.deleteIfExists(siblingSymlink)
+    Files.deleteIfExists(siblingFile.toPath)
+    Files.deleteIfExists(siblingDir.toPath)
     Files.deleteIfExists(dirWithLink.toPath)
     Files.deleteIfExists(tempDir)
   }
@@ -66,6 +79,17 @@ class FileAndResourceDirectivesSymlinkSpec extends RoutingSpec
           /* TODO: resurrect following links under an option
           responseAs[String] shouldEqual "123"
           mediaType shouldEqual `application/pdf`*/
+        }
+      }
+    }
+
+    "not follow symbolic links into a sibling directory whose name starts with the served directory" in {
+      Files.isSymbolicLink(siblingSymlink) shouldBe true
+      // the canonical location of the file is `<tmp>/dirWithLink-private/secret.txt`, which has the canonical
+      // path of the served directory, `<tmp>/dirWithLink`, as a string prefix
+      EventFilter.warning(pattern = ".* points to a location that is not part of .*", occurrences = 1).intercept {
+        Get("linked-sibling/secret.txt") ~> _getFromDirectory() ~> check {
+          handled shouldBe false
         }
       }
     }

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -16,7 +16,7 @@ package directives
 
 import java.io.{ File, FileNotFoundException, IOException, InputStream }
 import java.net.{ JarURLConnection, URL, URLConnection }
-import java.nio.file.Paths
+import java.nio.file.{ InvalidPathException, Paths }
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
@@ -236,9 +236,12 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
    *    to files containing one of those characters on a file-system that allows those characters in file names
    *    (e.g. backslash on posix).
    *  - Resulting paths are checked to be "contained" in the base directory. "Contained" means that the canonical location
-   *    of the file (according to File.getCanonicalPath) has the canonical version of the basePath as a prefix. The exact
-   *    semantics depend on the implementation of `File.getCanonicalPath` that may or may not resolve symbolic links and
-   *    similar structures depending on the OS and the JDK implementation of file system accesses.
+   *    of the file (according to File.getCanonicalPath) has the canonical version of the basePath as a path-element
+   *    prefix, compared element by element rather than as strings, so that a sibling directory whose name merely starts
+   *    with the base path's name is not treated as contained. The exact semantics depend on the implementation of
+   *    `File.getCanonicalPath` that may or may not resolve symbolic links and similar structures depending on the OS and
+   *    the JDK implementation of file system accesses; on Windows in particular it does not resolve NTFS symbolic links
+   *    and junctions, so a link out of the base directory is not detected there.
    */
   private def safeDirectoryChildPath(basePath: String, path: Uri.Path, log: LoggingAdapter,
       separator: Char = File.separatorChar): String =
@@ -272,12 +275,21 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
   private def checkIsSafeDescendant(basePath: String, finalPath: String, log: LoggingAdapter): String = {
     val baseFile = new File(basePath)
     val finalFile = new File(finalPath)
-    val canonicalFinalPath = finalFile.getCanonicalPath
 
     // compared element by element instead of as plain strings: `/var/www-private/secret` has the canonical path of
     // `/var/www` as a string prefix without being contained in that directory, which canonicalization can produce
     // for a symbolic link that points at a sibling directory
-    if (!Paths.get(canonicalFinalPath).startsWith(Paths.get(baseFile.getCanonicalPath))) {
+    val canonicalFinalPath =
+      try {
+        val canonical = finalFile.getCanonicalPath
+        if (Paths.get(canonical).startsWith(Paths.get(baseFile.getCanonicalPath))) canonical else ""
+      } catch {
+        // a segment can contain characters that no file-system path may hold (NUL on all platforms, '<' and
+        // similar on Windows): getCanonicalPath and Paths.get throw on those, and such a file cannot exist anyway
+        case _: InvalidPathException | _: IOException => ""
+      }
+
+    if (canonicalFinalPath.isEmpty) {
       log.warning("[{}] points to a location that is not part of [{}]. This might be a directory traversal attempt.",
         finalFile, baseFile)
       ""

--- a/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/http/src/main/scala/org/apache/pekko/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -16,6 +16,7 @@ package directives
 
 import java.io.{ File, FileNotFoundException, IOException, InputStream }
 import java.net.{ JarURLConnection, URL, URLConnection }
+import java.nio.file.Paths
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
@@ -273,7 +274,10 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
     val finalFile = new File(finalPath)
     val canonicalFinalPath = finalFile.getCanonicalPath
 
-    if (!canonicalFinalPath.startsWith(baseFile.getCanonicalPath)) {
+    // compared element by element instead of as plain strings: `/var/www-private/secret` has the canonical path of
+    // `/var/www` as a string prefix without being contained in that directory, which canonicalization can produce
+    // for a symbolic link that points at a sibling directory
+    if (!Paths.get(canonicalFinalPath).startsWith(Paths.get(baseFile.getCanonicalPath))) {
       log.warning("[{}] points to a location that is not part of [{}]. This might be a directory traversal attempt.",
         finalFile, baseFile)
       ""


### PR DESCRIPTION
### Motivation
`checkIsSafeDescendant` in `FileAndResourceDirectives` decides whether a requested file is really below the served directory by comparing the two canonical paths as plain strings:

```scala
if (!canonicalFinalPath.startsWith(baseFile.getCanonicalPath))
```

A string prefix is not a path prefix. With `/var/www` served, the location `/var/www-private/secret` satisfies `startsWith` without being contained in the served directory. The segment filter in `safeJoinPaths` does not catch this, since no path segment is suspicious — the path only moves out of the directory when `getCanonicalPath` resolves a symbolic link that points at such a sibling. The file is then served.

### Modification
Compare the canonical paths element by element through `java.nio.file.Path` rather than as strings. The base directory itself still compares as contained, which the directory listing in `getFromBrowseableDirectory` relies on (its root listing resolves to exactly the base path).

### Result
Only files that are genuinely below the served directory are served. A symbolic link into a sibling directory is rejected with the warning that was already there, whatever the sibling is called. Requests that were previously served are unaffected, and the existing symlink and traversal tests still pass.

### Tests
- `sbt "http-tests/testOnly org.apache.pekko.http.scaladsl.server.directives.FileAndResourceDirectivesSymlinkSpec"` - pass; new test serves through a symlink pointing at a sibling directory named after the served one, and asserts the request is rejected. Verified that it fails without the change (the file is served, `handled` is `true`).
- `sbt http-tests/test` - pass (1484 tests)
- `sbt http/mimaReportBinaryIssues` - pass
- `sbt http/scalafmt http-tests/Test/scalafmt` - clean

### References
None - tightens the containment check for file and resource directives
