### PR TITLE
Stop parsing chunks once the chunk count limit is reached

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
@@ -281,16 +281,19 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
         if (chunkCount >= settings.maxChunkCount)
           failEntityStream(
             s"HTTP chunk count exceeds the configured limit of ${settings.maxChunkCount} chunks")
-        val chunkBodyEnd = cursor + chunkSize
-        def result(terminatorLen: Int) = {
-          emit(EntityChunk(HttpEntity.Chunk(input.slice(cursor, chunkBodyEnd).compact, extension)))
-          Trampoline(_ =>
-            parseChunk(input, chunkBodyEnd + terminatorLen, isLastMessage, totalBytesRead + chunkSize, chunkCount + 1))
-        }
-        byteAt(input, chunkBodyEnd) match {
-          case CR_BYTE if byteAt(input, chunkBodyEnd + 1) == LF_BYTE => result(2)
-          case LF_BYTE                                               => result(1)
-          case x                                                     => failEntityStream("Illegal chunk termination")
+        else {
+          val chunkBodyEnd = cursor + chunkSize
+          def result(terminatorLen: Int) = {
+            emit(EntityChunk(HttpEntity.Chunk(input.slice(cursor, chunkBodyEnd).compact, extension)))
+            Trampoline(_ =>
+              parseChunk(input, chunkBodyEnd + terminatorLen, isLastMessage, totalBytesRead + chunkSize,
+                chunkCount + 1))
+          }
+          byteAt(input, chunkBodyEnd) match {
+            case CR_BYTE if byteAt(input, chunkBodyEnd + 1) == LF_BYTE => result(2)
+            case LF_BYTE                                               => result(1)
+            case x                                                     => failEntityStream("Illegal chunk termination")
+          }
         }
       } else parseTrailer(extension, cursor)
 

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
@@ -337,6 +337,29 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 
+      "stop parsing a request that has more chunks than the configured limit" in new Test {
+        override protected def parserSettings: ParserSettings = super.parserSettings.withMaxChunkCount(2)
+
+        val input = prep(start +
+          """1
+            |a
+            |1
+            |b
+            |1
+            |c
+            |0
+            |
+            |""")
+        // collect the raw parser output: nothing must be emitted after the error, in particular no further chunk
+        val outputs =
+          Source.single(SessionBytes(TLSPlacebo.dummySession, ByteString(input)))
+            .via(newParser).runWith(Sink.seq).awaitResult(awaitAtMost)
+
+        outputs.collect { case EntityChunk(chunk) => chunk.data.utf8String } shouldEqual Seq("a", "b")
+        outputs.last shouldEqual EntityStreamError(
+          ErrorInfo("HTTP chunk count exceeds the configured limit of 2 chunks"))
+      }
+
       "don't overflow the stack for large buffers of chunks" in new Test {
         override val awaitAtMost = 10000.millis.dilated
 


### PR DESCRIPTION
### Motivation

This is a bug in #1195

The `max-chunk-count` check in `HttpMessageParser.parseChunkBody` is missing its `else`:

```scala
if (chunkSize > 0) {
  if (chunkCount >= settings.maxChunkCount)
    failEntityStream(s"HTTP chunk count exceeds the configured limit of ${settings.maxChunkCount} chunks")
  val chunkBodyEnd = cursor + chunkSize
  ...  // emits the chunk and trampolines into the next one regardless
```

`failEntityStream` does not throw — it emits an `EntityStreamError`, sets `terminated = true` and returns a `StateResult` (`done()` is `null`). Its result is dropped here, so after the error the parser emits the current chunk, continues with the next one, and emits a further error for every remaining chunk in the buffer, i.e. it keeps producing output after it has terminated itself. Every other limit in this parser is written as `if (cond) failEntityStream(...) else <continue>`.

This is not a bypass: the error is emitted before the chunk, so a consumer that stops at the first error still fails the entity stream, which is presumably why it went unnoticed — there is no test for `max-chunk-count` in the repo. But the parser does work it should not, and it emits the whole rest of the body behind the error.

### Modification
Move the rest of `parseChunkBody` into the `else` branch of the check.

### Result
Nothing is emitted after the chunk count error and the parser stops parsing the remainder of the body.

### Tests
- `sbt "http-core/testOnly org.apache.pekko.http.impl.engine.parsing.RequestParserCRLFSpec org.apache.pekko.http.impl.engine.parsing.RequestParserLFSpec"` - pass, with a new test that collects the raw parser output for a body of three chunks with `max-chunk-count = 2`. It asserts that only the chunks `"a"` and `"b"` are emitted and that the error is the last output. Without the change the parser emits `"a", "b", "c", ""`, so the test fails. It deliberately reads the parser output directly, because the existing harness cancels the rest of the stream at the first error and therefore cannot see the difference.
- `sbt http-core/test` - pass (1216 tests)
- `sbt http-core/mimaReportBinaryIssues` - pass
- `sbt http-core/scalafmt http-core/Test/scalafmt` - clean

### References
None - makes the max-chunk-count limit stop parsing
