### PR TITLE
test: cover Locale.ROOT lowercasing paths from #1086

### DIFF
--- a/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/TurkishISpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/scaladsl/model/TurkishISpec.scala
@@ -40,5 +40,34 @@ class TurkishISpec extends AnyWordSpec with Matchers {
         Locale.setDefault(previousLocale)
       }
     }
+
+    "parse a header name containing a capital I in the turkish locale" in withTurkishLocale {
+      HttpHeader.parse("If-Match", "\"xyzzy\"") match {
+        case HttpHeader.ParsingResult.Ok(header, Nil) => header shouldBe a[headers.`If-Match`]
+        case other                                    => fail(s"Expected a modelled If-Match header but got $other")
+      }
+    }
+
+    "normalize a uri scheme containing a capital I in the turkish locale" in withTurkishLocale {
+      Uri(scheme = "IPP", authority = Uri.Authority(Uri.Host("example.com"))).scheme shouldEqual "ipp"
+    }
+
+    "resolve a media type for an upper case file extension in the turkish locale" in withTurkishLocale {
+      MediaTypes.forExtension("TIFF") shouldEqual MediaTypes.`image/tiff`
+    }
+
+    "lowercase an error header name in the turkish locale" in withTurkishLocale {
+      ErrorInfo("summary", "detail").withErrorHeaderName("If-Match").errorHeaderName shouldEqual "if-match"
+    }
+  }
+
+  private def withTurkishLocale(body: => Any): Unit = {
+    val previousLocale = Locale.getDefault
+    try {
+      Locale.setDefault(new Locale("tr", "TR"))
+      body
+    } finally {
+      Locale.setDefault(previousLocale)
+    }
   }
 }

--- a/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/TurkishLocaleDirectivesSpec.scala
+++ b/http-tests/src/test/scala/org/apache/pekko/http/scaladsl/server/directives/TurkishLocaleDirectivesSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.scaladsl.server.directives
+
+import java.util.Locale
+
+import org.apache.pekko
+import pekko.http.scaladsl.model.headers.RawHeader
+import pekko.http.scaladsl.server._
+
+/**
+ * Directives that lower- or upper-case a user supplied name must do so with `Locale.ROOT`,
+ * otherwise they break in locales like tr-TR where 'I' does not lowercase to 'i'.
+ */
+class TurkishLocaleDirectivesSpec extends RoutingSpec {
+
+  "The headerValueByName directive" should {
+    "extract a header whose name contains a capital I in the turkish locale" in withTurkishLocale {
+      lazy val route = headerValueByName("If-Match") { value => complete(value) }
+      Get("abc") ~> RawHeader("If-Match", "\"xyzzy\"") ~> route ~> check {
+        responseAs[String] shouldEqual "\"xyzzy\""
+      }
+    }
+  }
+
+  "The overrideMethodWithParameter directive" should {
+    "override with a method name containing an i in the turkish locale" in withTurkishLocale {
+      lazy val route = overrideMethodWithParameter("_method") {
+        get { complete("GET") } ~
+        options { complete("OPTIONS") }
+      }
+      Get("/?_method=options") ~> route ~> check { responseAs[String] shouldEqual "OPTIONS" }
+    }
+  }
+
+  private def withTurkishLocale(body: => Any): Unit = {
+    val previousLocale = Locale.getDefault
+    try {
+      Locale.setDefault(new Locale("tr", "TR"))
+      body
+    } finally {
+      Locale.setDefault(previousLocale)
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
#1086 moved a dozen call sites to `Locale.ROOT` but landed without tests. On `main` today the only turkish-i coverage is the `HttpCharsets` case in `TurkishISpec`, and nothing exercises the two directives that were fixed, so a regression would only surface for users running with a turkish default locale.

Two gaps worth calling out:

- The obvious `Uri` test does not actually cover the fixed code. `Uri("IPP://example.com")` passes even against pre-#1086 code, because the string parser lowercases the scheme through the ASCII-only `CharUtils.toLowerCase` in `UriParser.appendLowered` and never reaches `Uri.normalizeScheme`. The test here uses `Uri(scheme = "IPP", authority = ...)`, which does go through `normalizeScheme`.
- `headerValueByName` and `overrideMethodWithParameter` live in the `http` module, so they need a spec outside `http-core`.

### Modification
- `TurkishISpec` (http-core): four new cases under a `tr-TR` default locale covering `HttpHeader.parse`, `Uri` scheme normalization, `MediaTypes.forExtension` and `ErrorInfo.withErrorHeaderName`.
- New `TurkishLocaleDirectivesSpec` (http-tests): covers `headerValueByName("If-Match")` and `overrideMethodWithParameter` with `_method=options` (`"options".toUpperCase` under `tr-TR` is `OPTİONS`, which used to yield `501 Not Implemented`).

Both specs restore the previous default locale in a `finally`. Test-only change; no production code is touched.

### Result
The paths #1086 fixed are pinned, and the same cases are available to check backports against.

### Tests
- `sbt "http-core / Test / testOnly org.apache.pekko.http.scaladsl.model.TurkishISpec"` - 5 passed (JDK 21).
- `sbt "http-tests / Test / testOnly org.apache.pekko.http.scaladsl.server.directives.TurkishLocaleDirectivesSpec"` - 2 passed. Both fail when `headerValueByName` and `overrideMethodWithParameter` are locally reverted to default-locale case conversion, so the cases are directional.
- The four `TurkishISpec` cases likewise all fail against `1.4.x` without #1086 (verified while preparing the backport in #1224).
- `sbt headerCreateAll` - added the standard Apache header to the new file.
- `scalafmt --mode diff-ref=upstream/main` - clean.

### References
Refs #1086, Refs #1224