### PR TITLE
fix: drop removed UseBiasedLocking option from benchmark JVM args

### DIFF
--- a/http-bench-jmh/src/main/scala/org/apache/pekko/http/CommonBenchmark.scala
+++ b/http-bench-jmh/src/main/scala/org/apache/pekko/http/CommonBenchmark.scala
@@ -37,7 +37,6 @@ import org.openjdk.jmh.annotations.Warmup
     "-XX:InitialCodeCacheSize=512m",
     "-XX:ReservedCodeCacheSize=512m",
     "-XX:+UseParallelGC",
-    "-XX:-UseBiasedLocking",
     "-XX:+AlwaysPreTouch"))
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)


### PR DESCRIPTION
### Motivation
`CommonBenchmark` forks its benchmark JVM with `-XX:-UseBiasedLocking`. Biased locking was disabled by default and the flag deprecated in JDK 15 (JEP 374), and JDK 21 does not recognise it at all, so the forked VM aborts before running anything:

```
# Fork: 1 of 1
Unrecognized VM option 'UseBiasedLocking'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
<forked VM failed with exit code 1>
```

Every benchmark deriving from `CommonBenchmark` is unrunnable on a current JDK: `ConnectionPoolBenchmark`, `ServerProcessingBenchmark`, `StreamServerProcessingBenchmark`, `HttpEntityBenchmark`, `H2ServerProcessingBenchmark`, `H2ClientServerBenchmark` and `MaskingBench`. Benchmarks that do not extend it (`HeaderParserBenchmark`, `LineParserBenchmark`, …) declare their own JMH annotations and are unaffected.

The build already targets JDK 17 as a minimum (`javacTarget` in `project/Common.scala`), and biased locking is off by default from JDK 15 on, so the flag buys nothing on any JDK this project supports.

### Modification
Remove the option from the `@Fork` `jvmArgs`. The rest of the fork configuration is unchanged.

### Result
The benchmarks run again on a current JDK.

### Tests
- `sbt "http-bench-jmh/Jmh/run -f 1 -wi 1 -i 1 -r 2 -w 1 .*MaskingBench.*"` on JDK 21: the forked VM fails to start before this change; after it the run completes (`MaskingBench.benchRequestProcessing thrpt 122842.451 ops/s`).
- Only JDK 21 was available locally, so the JDK 17 path was not exercised. There the flag is at worst ignored with a warning, so removing it cannot make things worse.
- `scalafmt --mode diff-ref=upstream/main` - clean.

### References
None - found while benchmarking the HTTP parsers