### PR TITLE
chore: replace deprecated String constructor in StringTools

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/StringTools.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/StringTools.scala
@@ -16,18 +16,16 @@ package org.apache.pekko.http.impl.util
 import org.apache.pekko
 import pekko.annotation.InternalApi
 
-import scala.annotation.nowarn
-
 /**
  * INTERNAL API
  */
 @InternalApi
 private[http] object StringTools {
-  @nowarn("msg=deprecated")
   def asciiStringFromBytes(bytes: Array[Byte]): String =
-    // Deprecated constructor but also (unfortunately) the fastest way to convert a ASCII encoded byte array
-    // into a String without extra copying.
-    new String(bytes, 0)
+    // ISO-8859-1 rather than US-ASCII: this maps every byte to the character of the same value, which
+    // is what the deprecated `new String(bytes, 0)` this replaces did. Since JDK 9 (compact strings) it
+    // keeps the array as is with a LATIN1 coder, so it is the same single copy.
+    new String(bytes, ISO88591)
 
   def asciiStringBytes(string: String): Array[Byte] = {
     // this is as fast as Unsafe.copyUSAsciiStrToBytes for recent JDK versions

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/StringToolsSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/StringToolsSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.impl.util
+
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class StringToolsSpec extends AnyWordSpec with Matchers {
+
+  "StringTools.asciiStringFromBytes" should {
+    "map every byte to the character of the same value" in {
+      // HPACK string literals are opaque octets, so bytes above 0x7F do reach this method. They must
+      // keep mapping to the character of the same value rather than to a replacement character, which
+      // is what decoding as US-ASCII would do.
+      val allBytes = Array.tabulate(256)(_.toByte)
+      val decoded = StringTools.asciiStringFromBytes(allBytes)
+
+      decoded.length shouldEqual 256
+      decoded.toSeq.map(_.toInt) shouldEqual (0 until 256)
+    }
+
+    "round-trip an ASCII string through asciiStringBytes" in {
+      val original = "content-type: application/json"
+      StringTools.asciiStringFromBytes(StringTools.asciiStringBytes(original)) shouldEqual original
+    }
+
+    "decode an empty array to an empty string" in {
+      StringTools.asciiStringFromBytes(Array.emptyByteArray) shouldEqual ""
+    }
+  }
+
+  "StringTools.asciiStringBytes" should {
+    "encode an ASCII string to its US-ASCII bytes" in {
+      StringTools.asciiStringBytes("abc") shouldEqual "abc".getBytes(StandardCharsets.US_ASCII)
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
`StringTools.asciiStringFromBytes` uses the deprecated `new String(byte[], int hibyte)` behind a `@nowarn`, justified by this comment:

> Deprecated constructor but also (unfortunately) the fastest way to convert a ASCII encoded byte array into a String without extra copying.

That was true on Java 8, where the alternative expanded the bytes into a `char[]`. It stopped being true with JDK 9 and compact strings, and this branch requires JDK 17.

The method sits on the HTTP/2 HPACK decode path (`shaded/com/twitter/hpack/Decoder.readStringLiteral`), so it is worth being sure the replacement changes neither behaviour nor performance.

### Modification
```scala
-  @nowarn("msg=deprecated")
   def asciiStringFromBytes(bytes: Array[Byte]): String =
-    // Deprecated constructor but also (unfortunately) the fastest way to convert a ASCII encoded byte array
-    // into a String without extra copying.
-    new String(bytes, 0)
+    // ISO-8859-1 rather than US-ASCII: this maps every byte to the character of the same value, which
+    // is what the deprecated `new String(bytes, 0)` this replaces did. Since JDK 9 (compact strings) it
+    // keeps the array as is with a LATIN1 coder, so it is the same single copy.
+    new String(bytes, ISO88591)
```

plus dropping the now-unused `scala.annotation.nowarn` import. `ISO88591` is the constant already defined in this package (`impl/util/package.scala`).

**ISO-8859-1, not US-ASCII**, despite the method name. `new String(bytes, 0)` sets `char = byte & 0xFF` for every byte; ISO-8859-1 does exactly the same, so the two agree on every possible input. US-ASCII would turn bytes above 0x7F into `U+FFFD`, and HPACK string literals are opaque octets (RFC 7541), so such bytes really can arrive here. This matches the same decision made for `asciiString` in the parser.

### Result
No deprecated JDK API, no `@nowarn`, and no misleading Java-8-era comment, with identical behaviour.

I did not want to take the "compact strings make these identical" reasoning on trust, so:

- **Equivalence**: verified in jshell that both forms produce equal `String`s for all 256 byte values.
- **Performance**: JMH, average time, sizes 12 / 64 / 4096 bytes.

| | 12 B | 64 B | 4096 B |
|---|---|---|---|
| `new String(bytes, 0)` | 25.3 ± 7.0 ns | 30.2 ± 10.7 ns | 1260.2 ± 959.8 ns |
| `new String(bytes, ISO_8859_1)` | 28.2 ± 30.3 ns | 43.1 ± 72.5 ns | 952.7 ± 171.4 ns |

Error bars overlap at every size, so there is no measurable difference in either direction. (A crude jshell loop first suggested the charset form was ~2x slower at small sizes; that turned out to be warmup/ordering noise, which is why this was re-measured under JMH.)

### Tests
- New `StringToolsSpec` pins the byte-to-character mapping across the whole 0x00-0xFF range - the property that would break if someone later "corrected" the charset to US-ASCII to match the method name - plus a round-trip through `asciiStringBytes` and the empty-array case. `sbt "http-core / Test / testOnly org.apache.pekko.http.impl.util.StringToolsSpec"` - 4 passed. It is a regression guard, not a failing-before test; this change is deliberately behaviour preserving, so nothing can fail against it.
- `sbt http-core/mimaReportBinaryIssues` - clean.
- `scalafmt --mode diff-ref=upstream/main` - clean.
- I did not run the `http2-tests` suite that exercises the HPACK codec end to end; leaving that to CI.

### References
None - found while reviewing the code base against the JDK 17 baseline
