### PR TITLE
fix: read HPACK string literals with readNBytes

### DIFF
--- a/http-core/src/main/java/org/apache/pekko/http/shaded/com/twitter/hpack/Decoder.java
+++ b/http-core/src/main/java/org/apache/pekko/http/shaded/com/twitter/hpack/Decoder.java
@@ -529,8 +529,11 @@ public final class Decoder {
   }
 
   private String readStringLiteral(InputStream in, int length) throws IOException {
-    byte[] buf = new byte[length];
-    if (in.read(buf) != length) {
+    // readNBytes rather than read: InputStream.read(byte[]) is free to return fewer bytes than
+    // requested even when more are available, which would be reported here as a decompression
+    // failure
+    byte[] buf = in.readNBytes(length);
+    if (buf.length != length) {
       throw DECOMPRESSION_EXCEPTION;
     }
     final byte[] result;

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/http2/hpack/HpackDecoderSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/http2/hpack/HpackDecoderSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.impl.engine.http2.hpack
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream }
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.pekko.http.shaded.com.twitter.hpack.{ Decoder, Encoder, HeaderListener }
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HpackDecoderSpec extends AnyWordSpec with Matchers {
+
+  val maxHeaderSize = 4096
+  val maxHeaderTableSize = 4096
+
+  /**
+   * A stream that has all of its data available but hands it out in small pieces, which
+   * `InputStream.read(byte[])` is explicitly allowed to do.
+   */
+  private class TricklingInputStream(bytes: Array[Byte], bytesPerRead: Int) extends InputStream {
+    private val underlying = new ByteArrayInputStream(bytes)
+    override def read(): Int = underlying.read()
+    override def read(b: Array[Byte], off: Int, len: Int): Int =
+      underlying.read(b, off, math.min(len, bytesPerRead))
+    override def available(): Int = underlying.available()
+    override def markSupported(): Boolean = underlying.markSupported()
+    override def mark(readLimit: Int): Unit = underlying.mark(readLimit)
+    override def reset(): Unit = underlying.reset()
+    override def skip(n: Long): Long = underlying.skip(n)
+  }
+
+  private def encode(headers: (String, String)*): Array[Byte] = {
+    val out = new ByteArrayOutputStream
+    val encoder = new Encoder(maxHeaderTableSize)
+    headers.foreach { case (name, value) => encoder.encodeHeader(out, name, value, false) }
+    out.toByteArray
+  }
+
+  private def decode(in: InputStream): Seq[(String, String)] = {
+    val decoded = ListBuffer.empty[(String, String)]
+    val decoder = new Decoder(maxHeaderSize, maxHeaderTableSize)
+    decoder.decode(in,
+      new HeaderListener {
+        override def addHeader(name: String, value: String, parsed: AnyRef, sensitive: Boolean): AnyRef = {
+          decoded += (name -> value)
+          null
+        }
+      })
+    decoder.endHeaderBlock()
+    decoded.toList
+  }
+
+  "The HPACK decoder" should {
+    val headers = Seq("x-custom-header" -> "some-fairly-long-header-value", "another-header" -> "value")
+
+    "decode a header block from a stream that returns everything at once" in {
+      decode(new ByteArrayInputStream(encode(headers: _*))) shouldEqual headers
+    }
+
+    "decode a header block from a stream that returns one byte per read" in {
+      // string literals are read with a single call, so a short read must not be taken for truncation
+      decode(new TricklingInputStream(encode(headers: _*), bytesPerRead = 1)) shouldEqual headers
+    }
+
+    "decode a header block from a stream that returns a few bytes per read" in {
+      decode(new TricklingInputStream(encode(headers: _*), bytesPerRead = 7)) shouldEqual headers
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
`Decoder.readStringLiteral` asks for a whole HPACK string literal with a single `read` and treats anything shorter as a decompression failure:

```java
byte[] buf = new byte[length];
if (in.read(buf) != length) {
  throw DECOMPRESSION_EXCEPTION;
}
```

`InputStream.read(byte[])` is explicitly allowed to return fewer bytes than requested even when more are available, so this depends on a guarantee the API does not give.

**This is not an observable bug today**, and I want to be clear about that rather than oversell it. The only caller wraps a *compacted* `ByteString` - `HeaderDecompression.scala:99` does `payload.compact.asInputStream`, because the decoder needs `mark`/`reset` and a meaningful `available()` - and the decoder waits for `in.available() >= length` before calling `readStringLiteral`, so the single read always fills the buffer. What this change removes is a trap for anyone who later changes how that stream is produced.

### Modification
```java
byte[] buf = in.readNBytes(length);
if (buf.length != length) {
  throw DECOMPRESSION_EXCEPTION;
}
```

`readNBytes` loops until the requested count is read or the stream ends. Available since JDK 11; this branch requires JDK 17.

Truncated input is still reported as a decompression failure, and a zero-length literal still works (`readNBytes(0)` returns an empty array, matching the old `read` of an empty buffer).

This file is already adapted from github.com/twitter/hpack rather than kept byte-identical to upstream - it imports `org.apache.pekko.http.impl.util.StringTools` - so a local change here is in keeping with how it is maintained.

### Result
The decoder no longer depends on a single read filling the buffer, with no behaviour change for a stream that does.

### Note on a tempting follow-up
Fixing this does *not* on its own make it safe to drop the `.compact` in `HeaderDecompression` and save a copy per header block. The decoder also relies on `in.available()` reporting the full remaining length (`available() < nameLength` guards at `Decoder.java:280` and `:373`) and on `mark`/`reset`, neither of which a rope-backed `ByteString` InputStream provides. Worth a separate look, not a freebie from this change.

### Tests
- New `HpackDecoderSpec` round-trips header blocks through the shaded `Encoder` and `Decoder` over a stream that has all of its data available but hands it out 1 byte, and then 7 bytes, per `read`. **Both cases fail before this change** with `java.io.IOException: decompression failure`, and pass after it.
- `sbt "http-core / Test / testOnly org.apache.pekko.http.impl.engine.http2.hpack.HpackDecoderSpec"` - 3 passed.
- `sbt "http2-tests / Test / testOnly org.apache.pekko.http.impl.engine.http2.RequestParsingSpec"` - 25 passed, 3 pending.
- `sbt http-core/javafmtCheck` and `scalafmt` - clean. Note the Java formatter was run on JDK 21 rather than the JDK 17 the contributing guide suggests, since that is what was available here.

### References
None - found while reviewing the code base against the JDK 17 baseline
