### PR TITLE
perf: avoid copying WebSocket deflate/inflate output

### DIFF
--- a/http-core/src/main/mima-filters/2.0.x.backwards.excludes/illegal-request-context.excludes
+++ b/http-core/src/main/mima-filters/2.0.x.backwards.excludes/illegal-request-context.excludes
@@ -23,3 +23,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.impl.e
 ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.http.impl.engine.parsing.ParserOutput#MessageStartError.unapply")
 
 # internal API: replaced by an instance level completion handling that can report the same context
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.http.impl.engine.parsing.HttpMessageParser.CompletionIsMessageStartError")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.impl.engine.parsing.HttpMessageParser.org$apache$pekko$http$impl$engine$parsing$HttpMessageParser$_setter_$completionIsMessageStartError_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.impl.engine.parsing.HttpMessageParser.completionIsMessageStartError")

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/PerMessageDeflate.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/ws/PerMessageDeflate.scala
@@ -17,7 +17,6 @@
 
 package org.apache.pekko.http.impl.engine.ws
 
-import java.io.ByteArrayOutputStream
 import java.util.Random
 import java.util.zip.Deflater
 import java.util.zip.Inflater
@@ -27,6 +26,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.http.impl.settings.WebSocketCompressionSettingsImpl
+import pekko.http.impl.util.ByteStringOutputStream
 import pekko.http.scaladsl.model.headers.WebSocketExtension
 import pekko.stream.scaladsl.BidiFlow
 import pekko.stream.scaladsl.Flow
@@ -246,7 +246,7 @@ private[http] object PerMessageDeflate {
       try {
         val input = if (appendTail) data ++ EmptyStoredBlock else data
         inflater.setInput(input.toArrayUnsafe())
-        val output = new ByteArrayOutputStream(1024)
+        val output = new ByteStringOutputStream(1024)
         var count = inflater.inflate(buffer)
         while (count > 0) {
           decompressedMessageBytes += count
@@ -255,7 +255,7 @@ private[http] object PerMessageDeflate {
           output.write(buffer, 0, count)
           count = inflater.inflate(buffer)
         }
-        ByteString.fromArrayUnsafe(output.toByteArray)
+        output.toByteStringUnsafe
       } catch {
         case ex: DataFormatException =>
           throw new ProtocolException(s"Invalid WebSocket compressed message: ${ex.getMessage}")
@@ -345,13 +345,13 @@ private[http] object PerMessageDeflate {
 
     private def deflate(data: ByteString, removeTail: Boolean): ByteString = {
       deflater.setInput(data.toArrayUnsafe())
-      val output = new ByteArrayOutputStream(1024)
+      val output = new ByteStringOutputStream(1024)
       var count = deflater.deflate(buffer, 0, buffer.length, Deflater.SYNC_FLUSH)
       while (count > 0) {
         output.write(buffer, 0, count)
         count = deflater.deflate(buffer, 0, buffer.length, Deflater.SYNC_FLUSH)
       }
-      val bytes = ByteString.fromArrayUnsafe(output.toByteArray)
+      val bytes = output.toByteStringUnsafe
       if (removeTail && bytes.endsWith(EmptyStoredBlock)) bytes.dropRight(EmptyStoredBlock.length) else bytes
     }
 

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/util/ByteStringOutputStream.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/util/ByteStringOutputStream.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.impl.util
+
+import java.io.ByteArrayOutputStream
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.util.ByteString
+
+/**
+ * INTERNAL API
+ *
+ * An [[java.io.OutputStream]] that buffers into a byte array like [[java.io.ByteArrayOutputStream]] but
+ * that can hand the buffered data over as a [[pekko.util.ByteString]] without copying it, unlike
+ * `ByteArrayOutputStream.toByteArray` which always creates a copy.
+ *
+ * Derived from the `ByteStringOutputStream` in Apache Pekko gRPC
+ * (https://github.com/apache/pekko-grpc/pull/862).
+ */
+@InternalApi
+private[http] final class ByteStringOutputStream(capacity: Int) extends ByteArrayOutputStream(capacity) {
+
+  /**
+   * Wraps the bytes written so far in a `ByteString`. The buffer may be shared with the returned
+   * `ByteString`, so this stream must not be written to, reset or reused afterwards.
+   */
+  def toByteStringUnsafe: ByteString =
+    if (count < 1) ByteString.empty
+    else if (count > (buf.length >> 1))
+      // Most of the buffer is used — wrap it to avoid a copy
+      ByteString.fromArrayUnsafe(buf, 0, count)
+    else
+      // Small amount of data in a large buffer — copy to right-size so the rest can be GC'd
+      ByteString.fromArray(buf, 0, count)
+}

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/util/ByteStringOutputStreamSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/util/ByteStringOutputStreamSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.http.impl.util
+
+import org.apache.pekko.util.ByteString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ByteStringOutputStreamSpec extends AnyWordSpec with Matchers {
+
+  "ByteStringOutputStream" must {
+
+    "return an empty ByteString when nothing was written" in {
+      new ByteStringOutputStream(16).toByteStringUnsafe should ===(ByteString.empty)
+    }
+
+    "return the bytes written when the buffer is exactly filled" in {
+      val out = new ByteStringOutputStream(4)
+      out.write(Array[Byte](1, 2, 3, 4))
+      out.toByteStringUnsafe should ===(ByteString(1, 2, 3, 4))
+    }
+
+    "return the bytes written when the buffer was grown" in {
+      val out = new ByteStringOutputStream(2)
+      val data = Array.tabulate[Byte](1000)(i => i.toByte)
+      out.write(data)
+      out.toByteStringUnsafe should ===(ByteString(data))
+    }
+
+    "return the bytes written when only a small part of the buffer is used" in {
+      val out = new ByteStringOutputStream(1024)
+      out.write(Array[Byte](1, 2, 3))
+      out.write(4)
+      out.toByteStringUnsafe should ===(ByteString(1, 2, 3, 4))
+    }
+
+    "not retain the buffer when only a small part of it is used" in {
+      val out = new ByteStringOutputStream(1024)
+      out.write(Array[Byte](1, 2, 3))
+      // the ByteString is a copy, so it is not affected by later writes to the stream
+      val result = out.toByteStringUnsafe
+      out.write(Array[Byte](9, 9, 9))
+      result should ===(ByteString(1, 2, 3))
+    }
+
+    "write single bytes and byte ranges" in {
+      val out = new ByteStringOutputStream(8)
+      out.write(1)
+      out.write(Array[Byte](0, 2, 3, 0), 1, 2)
+      out.write(Array[Byte](4, 5, 6, 7, 8))
+      out.toByteStringUnsafe should ===(ByteString(1, 2, 3, 4, 5, 6, 7, 8))
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
`PerMessageDeflate` buffers the output of the `Deflater`/`Inflater` in a `ByteArrayOutputStream` and then calls `ByteString.fromArrayUnsafe(output.toByteArray)`. `ByteArrayOutputStream.toByteArray` always copies the buffer, so every compressed or decompressed WebSocket frame pays a full copy of its payload.

### Modification
Add an internal `ByteStringOutputStream` (`@InternalApi`, `private[http]`) that extends `ByteArrayOutputStream` and exposes `toByteStringUnsafe`:

- when most of the buffer is used, the buffer is wrapped via `ByteString.fromArrayUnsafe(buf, 0, count)` with no copy;
- otherwise the bytes are copied to a right-sized array so a large buffer is not retained by a small payload.

The stream must not be written to or reused after `toByteStringUnsafe`, which is documented on the method. Both call sites (`inflate` and `deflate` in `PerMessageDeflate`) allocate the stream per call and discard it immediately afterwards.

`HeaderCompression` also uses a `ByteArrayOutputStream`, but it reuses one instance across frames via `reset()`, so it is left unchanged here.

### Result
No copy of the payload per WebSocket frame when `permessage-deflate` is enabled, and no oversized buffer retained when a frame only fills a small part of it.

Note that `toByteStringUnsafe` can return a non-compact `ByteString1`, so a consumer that calls `toArrayUnsafe()` on the result will copy - that is the same single copy as before, just moved, and it is avoided entirely for consumers that do not need an array.

### Tests
- `sbt "http-core/testOnly org.apache.pekko.http.impl.util.ByteStringOutputStreamSpec org.apache.pekko.http.impl.engine.ws.WebSocketServerSpec"` - 51 tests succeeded, 0 failed
- New `ByteStringOutputStreamSpec` covers the empty, exactly-filled, grown-buffer and small-write-in-a-large-buffer cases, including that the copied result is unaffected by later writes to the stream
- `scalafmt --list --mode diff-ref=upstream/main` - no files reported
- `sbt headerCreateAll` - used to add the headers for the new files
- MiMa not run - the change is confined to `@InternalApi private[http]` code and adds no public API

### References
None - the `ByteStringOutputStream` implementation is adapted from Apache Pekko gRPC (Apache License 2.0), https://github.com/apache/pekko-grpc/pull/862