### PR TITLE
fix: render Content-Length for HEAD responses with a declared length

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/method-directives/head.md
+++ b/docs/src/main/paradox/routing-dsl/directives/method-directives/head.md
@@ -23,6 +23,14 @@ stripping off the result body. See the `pekko.http.server.transparent-head-reque
 this behavior.
 @@@
 
+@@@ note
+The response body is stripped off, but the `Content-Length` header is still rendered when the entity declares a
+non-zero length, so that clients can learn the size of the resource without fetching it. Entities without a known
+length (`Chunked`, `CloseDelimited`) and empty entities render no `Content-Length`; if you want to answer a HEAD
+request with the size of the hypothetical GET response without producing the bytes, complete with
+`HttpEntity.Default(contentType, length, Source.empty)`.
+@@@
+
 ## Example
 
 Scala

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -252,8 +252,16 @@ private[http] class HttpResponseRendererFactory(
               r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf
           }
 
+          // RFC 9112 section 6.3 rule 1 exempts responses to HEAD requests from body framing, so a Content-Length
+          // is pure metadata there and cannot desync the connection. Only render a length the application actually
+          // declared: a zero length nearly always means that there was no body to hand over rather than that the
+          // resource is empty, and our own client only honours a HEAD Content-Length when it is greater than zero
+          // (see HttpResponseParser).
           def renderContentLengthHeader(contentLength: Long) =
-            if (ctx.requestMethod.contentLengthAllowed(status)) r ~~ ContentLengthBytes ~~ contentLength ~~ CrLf else r
+            if (ctx.requestMethod.contentLengthAllowed(status) &&
+              (contentLength > 0 || ctx.requestMethod != HttpMethods.HEAD))
+              r ~~ ContentLengthBytes ~~ contentLength ~~ CrLf
+            else r
 
           def headersAndEntity(entityBytes: => Source[ByteString, Any]): StrictOrStreamed =
             if (noEntity) {

--- a/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMethod.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpMethod.scala
@@ -95,8 +95,10 @@ object HttpMethods extends ObjectRegistry[String, HttpMethod] {
   // for CONNECT it is explicitly not allowed in the 2xx (Successful) range
   private def contentLengthAllowedForConnect(forStatus: StatusCode): Boolean = forStatus.intValue < 200 ||
     forStatus.intValue >= 300
-  // for HEAD it is technically allowed, but must match the content-length of hypothetical GET request, so can not be anticipated
-  private def contentLengthAllowedForHead(forStatus: StatusCode): Boolean = false
+  // for HEAD it is allowed (RFC 9110 section 8.6) and should match the content-length of the hypothetical GET
+  // request; the renderer additionally suppresses a zero length, which usually means that the application had no
+  // body to hand over rather than that the resource is empty
+  private def contentLengthAllowedForHead(forStatus: StatusCode): Boolean = forStatus.allowsEntity
   // for other methods there are common rules:
   // - for 1xx (Informational) or 204 (No Content) it is explicitly not allowed
   // - for 304 (Not Modified) it must match the content-length of hypothetical 200-accepted request, so can not be anticipated

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -223,7 +223,7 @@ class HostConnectionPoolSpec extends PekkoSpecWithMaterializer(
             conn1.pushResponse(HttpResponse(entity = HttpEntity.Default(ContentTypes.`application/octet-stream`, 100,
               Source.empty)))
             val res = expectResponse()
-            res.entity.contentLengthOption.get shouldEqual 0
+            res.entity.contentLengthOption.get shouldEqual 100
 
             // HEAD requests do not require to consume entity
 
@@ -242,7 +242,7 @@ class HostConnectionPoolSpec extends PekkoSpecWithMaterializer(
             conn1.pushResponse(HttpResponse(entity = HttpEntity.Default(ContentTypes.`application/octet-stream`, 100,
               Source.empty)))
             val res = expectResponse()
-            res.entity.contentLengthOption.get shouldEqual 0
+            res.entity.contentLengthOption.get shouldEqual 100
 
             // HEAD requests do not require consumption of entity but users might do anyway
             res.entity.discardBytes()

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -155,6 +155,21 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
+              |Content-Length: 23
+              |
+              |""", close = false)
+      }
+
+      "to a transparent HEAD request (empty Strict response entity)" in new TestSetup() {
+        ResponseRenderingContext(
+          requestMethod = HttpMethods.HEAD,
+          response = HttpResponse(
+            headers = List(Age(30), Connection("Keep-Alive")),
+            entity = HttpEntity.Empty)) should renderTo(
+          """HTTP/1.1 200 OK
+              |Age: 30
+              |Server: pekko-http/1.0.0
+              |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |
               |""", close = false)
       }
@@ -206,6 +221,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
               |Server: pekko-http/1.0.0
               |Date: Thu, 25 Aug 2011 09:10:29 GMT
               |Content-Type: text/plain; charset=UTF-8
+              |Content-Length: 100
               |
               |""", close = false)
       }
@@ -714,7 +730,7 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
                  |Server: pekko-http/1.0.0
                  |Date: Thu, 25 Aug 2011 09:10:29 GMT
                  |${renCH.fold("")(_.toString + "\n")}Content-Type: text/plain; charset=UTF-8
-                 |${if (headReq || resCD) "" else "Content-Length: 6\n"}
+                 |${if (resCD) "" else "Content-Length: 6\n"}
                  |${if (headReq) "" else "ENTITY"}""", close))
     }
   }

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/server/HttpServerSpec.scala
@@ -523,6 +523,7 @@ class HttpServerSpec extends PekkoSpec(
                |Server: pekko-http/test
                |Date: XXXX
                |Content-Type: text/plain; charset=UTF-8
+               |Content-Length: 4
                |
                |""")
         }
@@ -551,6 +552,7 @@ class HttpServerSpec extends PekkoSpec(
                |Server: pekko-http/test
                |Date: XXXX
                |Content-Type: text/plain; charset=UTF-8
+               |Content-Length: 4
                |
                |""")
         }


### PR DESCRIPTION
### Motivation

[PR #962](https://github.com/apache/pekko-http/pull/962) corrected `Content-Length` rendering for `205 Reset Content` and for `CONNECT` in the 2xx range. Those parts are right — [http4s/http4s#7919](https://github.com/http4s/http4s/issues/7919) cites pekko-http's 205 handling as the reference implementation. But the same PR also made `HEAD` responses drop `Content-Length` unconditionally, which is what #1236 reports.

That part looks like collateral rather than intent: #962 deleted six existing assertions across four tests without adding any that argue for the new behaviour, including the test named *"to a HEAD request setting a custom Content-Type and **Content-Length** (default response entity)"*, which now asserted the opposite of its own name, and the round-trip assertions in `HostConnectionPoolSpec` (`shouldEqual 100` → `shouldEqual 0`).

The suppression is not required by the spec, and it leaves the codebase inconsistent:

- **RFC 9110 §8.6** says a server MAY send `Content-Length` in a HEAD response, and it SHOULD equal what a GET would return.
- **RFC 9112 §6.3 rule 1** exempts responses to HEAD requests from body framing entirely, so the header there is pure metadata and cannot desync a persistent connection.
- Our own **client** parser explicitly supports reading it — `HttpResponseParser.scala:186-195` turns HEAD + `Content-Length` into `HttpEntity.Default(ct, len, Source.empty)`.
- **HTTP/2 was never affected**: `http2/HttpMessageRendering.addContentHeaders` emits `content-length` straight from `entity.contentLengthOption` and never consults `contentLengthAllowed`, so the same application returned the header over h2 but not over h1.
- Even within HTTP/1.1, a HEAD + `Chunked` response still renders `Transfer-Encoding: chunked`, so framing metadata was mirrored for chunked but not for content length.

The concern behind the original change is real, though: a handler that special-cases HEAD and returns a bare `HttpResponse()` would render `Content-Length: 0`, which misrepresents what GET would return. So this PR does not simply revert the HEAD part.

### Modification

Two small edits:

1. `HttpMethods.contentLengthAllowedForHead` returns `forStatus.allowsEntity` instead of `false`, restoring the pre-1.4 predicate. A `Content-Length` *is* permitted on a HEAD response, so the public `HttpMethod.contentLengthAllowed` field no longer claims otherwise.
2. `HttpResponseRendererFactory.renderContentLengthHeader` adds the length-based policy: for HEAD, render only when the declared length is greater than zero.

That threshold separates "the application told us a length" from "we derived a length from a body we are about to discard":

| HEAD response entity | length | rendered? |
|---|---|---|
| `Strict(ct, 23 bytes)` | 23 | ✅ real length, body still dropped |
| `Default(ct, 100, Source.empty)` | 100 | ✅ the object-store / S3 case from #1236 |
| `Strict(ct, empty)` | 0 | ❌ means "no body here", not "0 bytes" |
| `CloseDelimited` / `Chunked` | — | ❌ unchanged; no known length |

It also matches the client exactly: `HttpResponseParser` honours a HEAD `Content-Length` only `if contentLength > 0`. Server and client now emit and accept the same set.

205, 204, 304 and CONNECT behaviour from #962 is untouched — `contentLengthAllowed(status)` still governs, and 205 keeps its `Content-Length: 0` because it is not a HEAD response.

No public signature changes; `sbt +mimaReportBinaryIssues` is clean.

### Result

A HEAD response completed with `HttpEntity.Strict` or `HttpEntity.Default(contentType, length, Source.empty)` renders the declared `Content-Length` again, as it did before 1.4.0. A HEAD response with an empty entity renders none.

### Tests

- `sbt "http-core / Test / testOnly org.apache.pekko.http.impl.engine.rendering.ResponseRendererSpec org.apache.pekko.http.impl.engine.server.HttpServerSpec org.apache.pekko.http.scaladsl.model.HttpMethodsSpec"` — 110 passed
- `sbt "http-core / Test / testOnly org.apache.pekko.http.impl.engine.client.HostConnectionPoolSpec"` — 66 passed
- `sbt +mimaReportBinaryIssues` — success
- `scalafmt --mode diff-ref=upstream/main` — clean; `git diff --check` — clean
- `sbt "http-core / test"` and `sbt "docs / paradox"` — not run to completion locally, left to CI

Directional coverage: the restored assertions in `ResponseRendererSpec` (`Content-Length: 23` and `100`), `HttpServerSpec` (`Content-Length: 4`, both the Strict and Default transparent-HEAD cases) and `HostConnectionPoolSpec` (server-renders → client-parses round trip, back to `100`) all fail without the fix. A new `ResponseRendererSpec` case, *"to a transparent HEAD request (empty Strict response entity)"*, guards the other direction by asserting that an empty entity renders no `Content-Length`.

### References

Fixes #1236, Refs #962, Refs http4s/http4s#7919