### PR TITLE
fix: keep the HPACK decoder usable after a header fails to parse

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -21,7 +21,7 @@ import pekko.http.impl.engine.http2.Http2Protocol.ErrorCode
 import pekko.http.impl.engine.http2.RequestParsing.parseHeaderPair
 import pekko.http.impl.engine.http2._
 import pekko.http.impl.engine.parsing.HttpHeaderParser
-import pekko.http.scaladsl.model.ParsingException
+import pekko.http.scaladsl.model.{ ErrorInfo, ParsingException }
 import pekko.http.scaladsl.settings.ParserSettings
 import pekko.http.shaded.com.twitter.hpack.HeaderListener
 import pekko.stream._
@@ -73,8 +73,14 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
       def parseAndEmit(
           streamId: Int, endStream: Boolean, payload: ByteString, prioInfo: Option[PriorityFrame]): Unit = {
         val headers = new VectorBuilder[(String, AnyRef)]
+        // A header that fails to parse must not unwind out of the decoder. Decoding has to run to the end of
+        // the block so that the HPACK dynamic table keeps tracking the peer's - insertHeader calls this
+        // listener before adding to the table, and the representations after this one would not be read at
+        // all - and so that endHeaderBlock resets the state machine. Both would otherwise stay wrong for
+        // every later HEADERS frame on the connection. Remember the first failure and report it afterwards.
+        var parsingError: Option[ErrorInfo] = None
         object Receiver extends HeaderListener {
-          def addHeader(name: String, value: String, parsed: AnyRef, sensitive: Boolean): AnyRef = {
+          def addHeader(name: String, value: String, parsed: AnyRef, sensitive: Boolean): AnyRef = try {
             if (parsed ne null) {
               headers += name -> parsed
               parsed
@@ -104,6 +110,12 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
                   handle(header)
               }
             }
+          } catch {
+            case ex: ParsingException =>
+              if (parsingError.isEmpty) parsingError = Some(ex.info)
+              // nothing usable to cache against the table entry, so the value is parsed again if it is
+              // referenced again - and fails again, consistently
+              null
           }
         }
         val stream = payload.compact.asInputStream
@@ -113,16 +125,28 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
           val truncated = decoder.endHeaderBlock()
 
           if (truncated) headerListSizeExceeded(streamId)
-          else push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
+          else
+            parsingError match {
+              // push details further and let RequestErrorFlow handle responding with bad request
+              case Some(info) =>
+                push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, Some(info)))
+              case None =>
+                push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
+            }
         } catch {
           case ex: ParsingException =>
-            // push details further and let RequestErrorFlow handle responding with bad request
+            // not expected any more now that the listener catches them, kept so that one thrown from
+            // somewhere else still answers with a bad request rather than tearing down the connection
             push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, Some(ex.info)))
           case _: IOException =>
             // this is signalled by the decoder when it failed, we want to react to this by rendering a GOAWAY frame
             fail(eventsOut,
               new Http2Compliance.Http2ProtocolException(ErrorCode.COMPRESSION_ERROR, "Decompression failed."))
         } finally {
+          // endHeaderBlock is what resets the decoder for the next block, so it has to run even when decode
+          // unwound anyway - a malformed pseudo header raises an Http2ProtocolException, for one. Running it
+          // a second time after the call above is a no-op.
+          decoder.endHeaderBlock()
           stream.close()
         }
       }

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -146,6 +146,22 @@ class Http2ClientServerSpec extends PekkoSpecWithMaterializer(
       response.status should be(StatusCodes.BadRequest)
     }
 
+    "keep the connection usable after a header parsing failure" in new TestSetup {
+      sendClientRequest(HttpRequest(
+        method = HttpMethod.custom("UNKNOWN_TO_SERVER"),
+        uri = "http://www.example.com/test").addAttribute(requestIdAttr, RequestId("bad")))
+      expectClientResponse().status should be(StatusCodes.BadRequest)
+
+      // the failing header must not have left the HPACK dynamic table out of step with the client's, nor the
+      // decoder's state machine part way through the previous block
+      sendClientRequest(
+        HttpRequest(uri = "http://www.example.com/afterwards").addAttribute(requestIdAttr, RequestId("good")))
+      val serverRequest = expectServerRequest()
+      serverRequest.request.uri.path.toString shouldBe "/afterwards"
+      serverRequest.sendResponse(HttpResponse(entity = "pong"))
+      expectClientResponse().status should be(StatusCodes.OK)
+    }
+
     "return internal server error when handler future fails" in new TestSetup {
       sendClientRequest()
       val serverRequest = expectServerRequest()


### PR DESCRIPTION
Noticed while working on #1251. A single malformed header currently makes every later HEADERS frame on that connection undecodable.

## The bug

`HeaderDecompression`'s `HeaderListener` threw `ParsingException` straight through the HPACK decoder. Three things follow from that, and they compound:

1. `Decoder.insertHeader` calls the listener **before** `dynamicTable.add(...)`, so the entry for the offending header never reached the table.
2. `decode()` unwound at that point, so every representation *after* it in the block was never read, and never added to the table either.
3. `endHeaderBlock()` sat inside the `try`, so it was skipped — leaving the decoder holding the `state` and `headerSize` of the abandoned block.

(1) and (2) desynchronise the decoder's dynamic table from the peer's encoder's, which is not something HPACK can recover from: from then on the peer's indexed references resolve to the wrong entries. (3) resumes the next block part way through a representation.

This is reachable, not theoretical. `HeaderDecompression` deliberately answers a parse failure with a bad request and keeps the connection open, so an unknown method — already covered by *"return bad request response when header parsing fails"* — is enough to trigger it.

## The fix

Catch `ParsingException` in the listener, remember the first `ErrorInfo`, and return `null` so decoding runs to the end of the block and the dynamic table keeps tracking the peer's. Report the remembered failure once the block is fully decoded, which produces the same bad request response as before.

`null` rather than the raw value on purpose: the decoder caches what the listener returns against the table entry, and caching an unparsed `String` where a `ContentType` is expected would hand a wrong type to a later indexed reference. `null` means it is parsed again — and fails again, consistently.

`endHeaderBlock()` also moves into a `finally`, so anything else that unwinds still resets the decoder — a malformed `:path` raises `Http2ProtocolException`, which is not a `ParsingException`. Running it twice on the success path is a no-op (`headerSize` is already 0). The outer `ParsingException` handler stays as a fallback for anything thrown outside the listener.

## Tests

New `"keep the connection usable after a header parsing failure"` in `Http2ClientServerSpec`: send a request with an unknown method, expect the bad request, then send a valid request on the same connection.

Verified it actually catches the bug — with the fix stashed so `HeaderDecompression` matched `main` exactly:

```
- should keep the connection usable after a header parsing failure *** FAILED ***
  java.lang.AssertionError: assertion failed: timeout (3 seconds) during expectMsgClass
  waiting for class ...Http2ClientServerSpec$ServerRequest
```

The follow-up request does not merely come back wrong — it never reaches the handler at all, which is the desync showing up end to end.

- `http2-tests/testOnly ...Http2ClientServerSpec` — 8 passed
- `http-core/testOnly org.apache.pekko.http.impl.engine.http2.*` — 13 passed
- `http2-tests/test` — 353 passed, 25 ignored, 26 pending
- `scalafmtCheckAll`, `headerCheck`, `http-core/mimaReportBinaryIssues` — clean

## Note on #1251

This is based on `main` so it can be reviewed and backported on its own. It touches the same `try` block that #1251 rewrites, so the two conflict textually; I will rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
