### PR TITLE
fix: count repeated Connection headers towards max-header-count

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
@@ -207,8 +207,11 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
         case h: Connection => ch match {
             case None =>
               parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, Some(h), clh, cth, isChunked, e100c, hh)
-            case Some(x) => parseHeaderLines(input, lineEnd, headers, headerCount, Some(x.append(h.tokens)), clh, cth,
-                isChunked, e100c, hh)
+            // count each merged Connection header towards the limit: the tokens are accumulated into `x` (an O(n) copy
+            // per header), so without incrementing headerCount the `headerCount < maxHeaderCount` guard never trips and
+            // a flood of Connection headers drives unbounded quadratic work from a single message
+            case Some(x) => parseHeaderLines(input, lineEnd, headers, headerCount + 1, Some(x.append(h.tokens)), clh,
+                cth, isChunked, e100c, hh)
           }
         case h: Host =>
           if (!hh || isResponseParser)

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
@@ -663,6 +663,28 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
           ErrorInfo("HTTP header value exceeds the configured limit of 32 characters"))
       }
 
+      "with more headers than the configured limit" in new Test {
+        override def parserSettings: ParserSettings = super.parserSettings.withMaxHeaderCount(2)
+        """GET / HTTP/1.1
+          |A: 1
+          |B: 2
+          |C: 3""" should parseToError(
+          BadRequest,
+          ErrorInfo("HTTP message contains more than the configured limit of 2 headers"))
+      }
+
+      "with more repeated Connection headers than the configured limit" in new Test {
+        // repeated Connection headers are merged into one, but each still counts towards maxHeaderCount so that a
+        // flood cannot bypass the limit and force unbounded quadratic token accumulation
+        override def parserSettings: ParserSettings = super.parserSettings.withMaxHeaderCount(2)
+        """GET / HTTP/1.1
+          |Connection: a
+          |Connection: b
+          |Connection: c""" should parseToError(
+          BadRequest,
+          ErrorInfo("HTTP message contains more than the configured limit of 2 headers"))
+      }
+
       "with an invalid Content-Length header value" in new Test {
         """GET / HTTP/1.0
           |Content-Length: 1.5


### PR DESCRIPTION
### Motivation

`HttpMessageParser.parseHeaderLines` merges repeated `Connection` headers into one accumulated header (`Some(x) => ...Some(x.append(h.tokens))...`), but that merge branch re-entered the loop with `headerCount` **unchanged**:

```scala
case h: Connection => ch match {
    case None =>
      parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, Some(h), ...)
    case Some(x) => parseHeaderLines(input, lineEnd, headers, headerCount, Some(x.append(h.tokens)), ...) // headerCount not incremented
  }
```

So the `headerCount < settings.maxHeaderCount` guard at the top of the loop never trips on additional `Connection` headers, and a single message can carry an unbounded number of them. `Connection.append` is `Connection(this.tokens ++ tokens)` — an O(n) copy of the accumulated token list per header — and there is no total-header-block byte limit, so N repeated `Connection` headers force ~N²/2 token copies plus an N-element list from one request. Every other non-deduplicated header increments the count via the generic branch; only this accumulating path did not, making it a `max-header-count` bypass with quadratic amplification.

The `Content-Length`/`Content-Type` duplicate branches also skip the increment, but they require a structurally identical value and do not accumulate, so they cannot be grown — `Connection` is the only unbounded merge.

### Modification

Increment `headerCount` in the `Connection` merge branch so each repeated `Connection` header counts towards `max-header-count`, matching the generic header path. Once the limit is reached the existing guard rejects the message with the standard "more than the configured limit" error, bounding the number of merges to `max-header-count` (default 64).

### Result

A flood of `Connection` headers is rejected at `max-header-count` instead of accumulating unboundedly; the parser's work on this path is bounded by the configured limit like every other header. Legitimate use (one or a few `Connection` headers) is unaffected — they were already counted the same way once the merge is charged.

### Tests

- `sbt "http-core/testOnly org.apache.pekko.http.impl.engine.parsing.RequestParserCRLFSpec org.apache.pekko.http.impl.engine.parsing.RequestParserLFSpec"` — pass (116 tests). Two new tests assert that exceeding `max-header-count` is rejected both for distinct headers and for repeated `Connection` headers. Verified the `Connection` test fails with the fix stashed (the flood is never caught, no error is emitted).
- `sbt http-core/mimaReportBinaryIssues` — pass (internal `impl.engine.parsing` change, no public API).
- Native `scalafmt` on the two changed files — clean.

### References

None - bounds repeated Connection header accumulation to max-header-count

🤖 Generated with [Claude Code](https://claude.com/claude-code)