### PR TITLE
fix: prevent CRLF injection through chunk trailers and extensions

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/RenderSupport.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/rendering/RenderSupport.scala
@@ -29,8 +29,6 @@ import pekko.stream.stage.GraphStage
 import pekko.stream._
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 
-import scala.collection.immutable
-
 /**
  * INTERNAL API
  */
@@ -52,9 +50,6 @@ private[http] object RenderSupport {
   private val TextXmlContentType = preRenderContentType(`text/xml(UTF-8)`)
   private val TextHtmlContentType = preRenderContentType(`text/html(UTF-8)`)
   private val TextCsvContentType = preRenderContentType(`text/csv(UTF-8)`)
-
-  implicit val trailerRenderer: Renderer[immutable.Iterable[HttpHeader]] =
-    Renderer.genericSeqRenderer[Renderable, HttpHeader](Rendering.CrLf, Rendering.Empty)
 
   val defaultLastChunkBytes: ByteString = renderChunk(HttpEntity.LastChunk)
 
@@ -156,12 +151,18 @@ private[http] object RenderSupport {
       2 + 2
     val r = new ByteStringRendering(renderedSize)
     r ~~% data.length
-    if (extension.nonEmpty) r ~~ ';' ~~ extension
+    // drop an extension carrying CR/LF: it is rendered raw into the chunk-size line, so a CR/LF would break the chunk
+    // framing / split the response. The extension is optional metadata, so omitting an illegal one is safe
+    if (extension.nonEmpty && extension.indexOf('\r') < 0 && extension.indexOf('\n') < 0) r ~~ ';' ~~ extension
     r ~~ CrLf
     chunk match {
       case HttpEntity.Chunk(data, _)        => r ~~ data
       case HttpEntity.LastChunk(_, Nil)     => // nothing to do
-      case HttpEntity.LastChunk(_, trailer) => r ~~ trailer ~~ CrLf
+      case HttpEntity.LastChunk(_, trailer) =>
+        // render each trailer header through the `~~(HttpHeader)` overload, which scans the rendered bytes for CR/LF
+        // and drops the header if it finds them; the generic sequence renderer would call `header.render` directly
+        // and let an attacker-controlled trailer value (e.g. a RawHeader) inject CRLF and split the response
+        trailer.foreach(r ~~ _)
     }
     r ~~ CrLf
     r.get

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -401,6 +401,50 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
         }
       }
 
+      "dropping a chunk trailer header whose value would inject CRLF into the response" in new TestSetup() {
+        // the trailer carries an attacker-controlled RawHeader value containing CRLF; it must be discarded rather
+        // than split the response, exactly as a header in the main header block is
+        HttpResponse(entity = Chunked(
+          ContentTypes.`text/plain(UTF-8)`,
+          source(
+            Chunk(ByteString("body123")),
+            LastChunk("", List(RawHeader("X-Trace", "ok\r\nSet-Cookie: injected=1"), Age(30)))))) should renderTo {
+          """HTTP/1.1 200 OK
+            |Server: pekko-http/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Transfer-Encoding: chunked
+            |Content-Type: text/plain; charset=UTF-8
+            |
+            |7
+            |body123
+            |0
+            |Age: 30
+            |
+            |"""
+        }
+      }
+
+      "dropping a chunk extension whose value would inject CRLF into the chunk framing" in new TestSetup() {
+        // the chunk extension is rendered raw into the chunk-size line; a CRLF in it must not corrupt the framing
+        HttpResponse(entity = Chunked(
+          ContentTypes.`text/plain(UTF-8)`,
+          source(
+            Chunk(ByteString("body123"), "ok\r\nSet-Cookie: injected=1"),
+            LastChunk))) should renderTo {
+          """HTTP/1.1 200 OK
+            |Server: pekko-http/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Transfer-Encoding: chunked
+            |Content-Type: text/plain; charset=UTF-8
+            |
+            |7
+            |body123
+            |0
+            |
+            |"""
+        }
+      }
+
       "with one chunk and and extra LastChunks at the end (which should be ignored)" in new TestSetup() {
         HttpResponse(entity = Chunked(
           ContentTypes.`text/plain(UTF-8)`,


### PR DESCRIPTION
### Motivation

`RenderSupport.renderChunk` emitted two attacker-influenceable parts of a chunked response **without** the CR/LF guard that the main header block relies on. The guard lives in the `~~(header: HttpHeader)` overload (`Rendering.scala`), which marks the position, renders the header, and then scans the rendered bytes for CR/LF — dropping the header if any are found. Only the main header loop went through it.

**Trailer headers** were rendered with `r ~~ trailer`, which resolves to the generic sequence renderer (`Renderer[immutable.Iterable[HttpHeader]]`) and calls `header.render(r)` directly, bypassing the guard:

```scala
case HttpEntity.LastChunk(_, trailer) => r ~~ trailer ~~ CrLf
```

`HttpEntity.LastChunk` and `RawHeader` perform no CR/LF validation, so a trailer built from user data splits the response:

```scala
HttpEntity.Chunked(ct, Source(List(
  HttpEntity.Chunk("body"),
  HttpEntity.LastChunk(trailer = List(RawHeader("X-Trace", "ok\r\nSet-Cookie: session=attacker"))))))
```

The identical `RawHeader` placed in the normal header list **is** caught by the guard; only because it rides in the trailer did it reach the wire.

**The chunk extension** was rendered raw into the chunk-size line with no CR/LF check:

```scala
if (extension.nonEmpty) r ~~ ';' ~~ extension
```

so a CR/LF in an app-set `HttpEntity.Chunk(data, extension)` corrupted the chunk framing.

### Modification

- Render each trailer header through the guarded `~~(HttpHeader)` overload (`trailer.foreach(r ~~ _)`), matching how the main header block renders (`HttpResponseRendererFactory.render(h) = r ~~ h`).
- Remove the now-unused `trailerRenderer` implicit, so the unguarded `Renderer[Iterable[HttpHeader]]` cannot be picked up again by accident.
- Skip a chunk extension containing CR/LF; the extension is optional metadata, so omitting an illegal one is safe.

Byte output is unchanged for valid trailers and extensions (verified by the existing rendering tests, which are exact-string comparisons).

### Result

CR/LF in a chunk trailer header value or a chunk extension can no longer reach the wire — the offending header/extension is dropped, exactly as in the main header block, instead of splitting the response.

### Tests

- `sbt "http-core/testOnly org.apache.pekko.http.impl.engine.rendering.ResponseRendererSpec org.apache.pekko.http.impl.engine.rendering.RequestRendererSpec"` — pass (62 tests). Two new tests assert that a CRLF-bearing trailer header and a CRLF-bearing chunk extension are dropped from the rendered output. Verified both fail with the fix stashed (the injected `Set-Cookie` bytes reach the output).
- `sbt http-core/mimaReportBinaryIssues` — pass (internal `impl.engine.rendering` change, no public API).
- Native `scalafmt` on the changed files — clean.

### References

None - closes the CRLF-injection paths in chunked response rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)