### PR TITLE
fix: reject whitespace between chunk-size digits

### DIFF
--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/parsing/HttpMessageParser.scala
@@ -305,23 +305,29 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
       } else failEntityStream(
         s"HTTP chunk extension length exceeds configured limit of ${settings.maxChunkExtLength} characters")
 
-    @tailrec def parseSize(cursor: Int, size: Long): StateResult =
+    // `sawWhitespace` records that the size digits are over and we are in trailing whitespace. Whitespace after the
+    // size is tolerated (illegal per the spec but seen in the wild, see issue #1812), but whitespace *between* size
+    // digits is not: without this a chunk size such as `5 0` would be read here as 0x50 = 80 bytes while a proxy that
+    // stops at the space reads 5, a request-smuggling discrepancy. Once whitespace is seen only more whitespace or a
+    // terminator may follow; a further hex digit falls through to the illegal-character case.
+    @tailrec def parseSize(cursor: Int, size: Long, sawWhitespace: Boolean): StateResult =
       if (size <= Int.MaxValue) {
         byteChar(input, cursor) match {
-          case c if CharacterClasses.HEXDIG(c)   => parseSize(cursor + 1, size * 16 + CharUtils.hexValue(c))
+          case c if CharacterClasses.HEXDIG(c) && !sawWhitespace =>
+            parseSize(cursor + 1, size * 16 + CharUtils.hexValue(c), sawWhitespace = false)
           case c if size > settings.maxChunkSize =>
             failEntityStream(
               s"HTTP chunk of $size bytes exceeds the configured limit of ${settings.maxChunkSize} bytes")
           case ';' if cursor > offset                                          => parseChunkExtensions(size.toInt, cursor + 1)()
           case '\r' if cursor > offset && byteAt(input, cursor + 1) == LF_BYTE =>
             parseChunkBody(size.toInt, "", cursor + 2)
-          case '\n' if cursor > offset      => parseChunkBody(size.toInt, "", cursor + 1)
-          case c if CharacterClasses.WSP(c) => parseSize(cursor + 1, size) // illegal according to the spec but can happen, see issue #1812
-          case c                            => failEntityStream(s"Illegal character '${escape(c)}' in chunk start")
+          case '\n' if cursor > offset                         => parseChunkBody(size.toInt, "", cursor + 1)
+          case c if CharacterClasses.WSP(c) && cursor > offset => parseSize(cursor + 1, size, sawWhitespace = true)
+          case c                                               => failEntityStream(s"Illegal character '${escape(c)}' in chunk start")
         }
       } else failEntityStream(s"HTTP chunk size exceeds Integer.MAX_VALUE (${Int.MaxValue}) bytes")
 
-    try parseSize(offset, 0)
+    try parseSize(offset, 0, sawWhitespace = false)
     catch {
       case NotEnoughDataException =>
         continue(input, offset)(parseChunk(_, _, isLastMessage, totalBytesRead, chunkCount))

--- a/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing/RequestParserSpec.scala
@@ -521,6 +521,28 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 
+      "whitespace between chunk size digits" in new Test {
+        // `5 0` must not be read as 0x50 = 80 bytes; a hex digit after whitespace is rejected so that this parser and
+        // a fronting proxy cannot disagree on the chunk size (request smuggling)
+        Seq(
+          start,
+          """5 0
+            |""") should generalMultiParseTo(
+          Right(baseRequest),
+          Left(EntityStreamError(ErrorInfo("Illegal character '0' in chunk start"))))
+        closeAfterResponseCompletion shouldEqual Seq(false)
+      }
+
+      "leading whitespace before the chunk size" in new Test {
+        Seq(
+          start,
+          """ 5
+            |""") should generalMultiParseTo(
+          Right(baseRequest),
+          Left(EntityStreamError(ErrorInfo("Illegal character ' ' in chunk start"))))
+        closeAfterResponseCompletion shouldEqual Seq(false)
+      }
+
       "an illegal char in chunk size" in new Test {
         Seq(start, "bla") should generalMultiParseTo(
           Right(baseRequest),


### PR DESCRIPTION
### Motivation

The chunked-body parser tolerates whitespace after the chunk-size digits (illegal per RFC 7230 but seen in the wild — see #1812), but the `WSP` arm recursed with the same accumulated `size` and then let parsing continue with the next character, **including a further hex digit**:

```scala
case c if CharacterClasses.HEXDIG(c)   => parseSize(cursor + 1, size * 16 + CharUtils.hexValue(c))
...
case c if CharacterClasses.WSP(c) => parseSize(cursor + 1, size) // see issue #1812
```

So a chunk size of `5 0` was parsed as `0x50` = **80 bytes**, whereas a proxy that stops at the space reads **5**. That size discrepancy is a request-smuggling primitive when Pekko HTTP sits behind such a proxy. The `#1812` comment intended only *trailing* whitespace tolerance; the code skipped *interior* whitespace as well. The `WSP` arm also lacked a `cursor > offset` guard, so a size field of only spaces parsed as 0.

### Modification

Thread a `sawWhitespace` flag through `parseSize`:

- Once whitespace has been seen, the hex-digit accumulation arm is guarded off (`HEXDIG(c) && !sawWhitespace`), so a subsequent hex digit falls through to the illegal-character case — only more whitespace or a terminator (`;`, CRLF, LF) may follow.
- The `WSP` arm now requires `cursor > offset`, so leading whitespace before any digit is rejected too.

Trailing whitespace after a complete size is unchanged (still tolerated).

### Result

`5 0` and ` 5` are now rejected with `Illegal character '...' in chunk start`, while `5<SP><SP>\r\n` (trailing BWS) still parses. Pekko HTTP and a fronting proxy can no longer disagree on the chunk size.

### Tests

- `sbt "http-core/testOnly org.apache.pekko.http.impl.engine.parsing.RequestParserCRLFSpec org.apache.pekko.http.impl.engine.parsing.RequestParserLFSpec"` — pass (116 tests). Two new tests reject `5 0` (interior whitespace) and ` 5` (leading whitespace); the existing "incorrect but harmless whitespace after chunk size" (#1812) test still passes. Verified the interior-whitespace test fails with the fix stashed (`5 0` parses as 80 bytes).
- `sbt http-core/mimaReportBinaryIssues` — pass (internal `impl.engine.parsing` change, no public API).
- Native `scalafmt` on the changed files — clean.

### References

Refs #1812 - narrows the whitespace tolerance to trailing whitespace only

🤖 Generated with [Claude Code](https://claude.com/claude-code)