### PR TITLE
fix: require every Origin to be allowed on a CORS request

### DIFF
--- a/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsDirectives.scala
+++ b/http-cors/src/main/scala/org/apache/pekko/http/cors/scaladsl/CorsDirectives.scala
@@ -67,9 +67,11 @@ trait CorsDirectives {
   def cors(settings: CorsSettings): Directive0 = {
     import settings._
 
-    // Return the invalid origins, or `Nil` if one is valid.
+    // Return the invalid origins, or `Nil` if they are all valid. Every origin has to match, not just one of them:
+    // the response echoes back every origin given, so accepting on a single match would echo an origin that was
+    // never allowed when a request lists a permitted origin alongside a disallowed one.
     def validateOrigins(origins: Seq[HttpOrigin]): List[CorsRejection.Cause] =
-      if (allowedOrigins == HttpOriginMatcher.* || origins.exists(allowedOrigins.matches)) {
+      if (allowedOrigins == HttpOriginMatcher.* || (origins.nonEmpty && origins.forall(allowedOrigins.matches))) {
         Nil
       } else {
         CorsRejection.InvalidOrigin(origins) :: Nil

--- a/http-cors/src/test/scala/org/apache/pekko/http/cors/CorsDirectivesSpec.scala
+++ b/http-cors/src/test/scala/org/apache/pekko/http/cors/CorsDirectivesSpec.scala
@@ -106,6 +106,19 @@ class CorsDirectivesSpec extends AnyWordSpec with Matchers with Directives with 
       }
     }
 
+    "reject an actual request listing a disallowed origin next to an allowed one" in {
+      val settings = referenceSettings.withAllowedOrigins(HttpOriginMatcher(exampleOrigin))
+      val disallowedOrigin = HttpOrigin("http://evil.com")
+
+      // the response echoes back every origin given, so accepting because one of them matches would echo the
+      // disallowed origin back to the caller
+      Get() ~> Origin(Seq(exampleOrigin, disallowedOrigin)) ~> {
+        route(settings)
+      } ~> check {
+        rejection shouldBe CorsRejection(CorsRejection.InvalidOrigin(Seq(exampleOrigin, disallowedOrigin)))
+      }
+    }
+
     "accept pre-flight requests with a null origin when allowed-origins = `*`" in {
       val settings = referenceSettings
       Options() ~> Origin(Seq.empty) ~> `Access-Control-Request-Method`(GET) ~> {


### PR DESCRIPTION
### Motivation

`validateOrigins` accepted a request as soon as **one** of the origins in the `Origin` header matched:

```scala
if (allowedOrigins == HttpOriginMatcher.* || origins.exists(allowedOrigins.matches)) Nil
```

but the response echoes back **every** origin it was given — `CorsSettingsImpl.accessControlAllowOrigin` renders the whole list. A request carrying an allowed origin next to a disallowed one therefore passed validation and echoed the disallowed origin back in `Access-Control-Allow-Origin`.

The pre-flight path is unaffected (it already only accepts a single origin), so this was limited to simple/actual requests. It is not directly browser-exploitable — the Fetch spec sends exactly one `Origin`, and a multi-origin `Access-Control-Allow-Origin` is invalid so a browser rejects it — but a value that never passed validation should not be reflected.

### Modification

Require all origins to match rather than any, keeping the existing `allowed-origins = *` short-circuit. The added `nonEmpty` guard preserves today's handling of a `null` origin (an empty origin list), which must still be rejected when the allowed origins are restricted — `forall` alone would accept it, since `Seq.empty.forall(_)` is `true`.

### Result

An actual request is accepted only when every origin it lists is allowed, so no origin that failed validation is echoed back. A request whose origins are all disallowed is still rejected with `InvalidOrigin` listing them, exactly as before.

### Tests

- `sbt http-cors/test` — pass (47 tests). A new test asserts that an actual request listing a disallowed origin next to an allowed one is rejected with `InvalidOrigin`. Verified it fails with the fix stashed (the request is accepted and both origins are echoed). The existing "there are two origins" rejection test and the restricted-`null`-origin test both still pass, which is what pins the `nonEmpty` guard.
- `sbt http-cors/mimaReportBinaryIssues` — pass.
- Native `scalafmt` on the changed files — clean.

### References

None - requires all origins of a CORS request to be allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)