### PR TITLE
release notes for 1.4.1

### DIFF
--- a/.github/workflows/publish-1.4-docs.yml
+++ b/.github/workflows/publish-1.4-docs.yml
@@ -47,22 +47,22 @@ jobs:
 
       - name: Build Documentation
         run: |-
-          sbt -Dpekko.genjavadoc.enabled=true "set ThisBuild / version := \"1.4.0\"; docs/paradox; unidoc"
+          sbt -Dpekko.genjavadoc.enabled=true "set ThisBuild / version := \"1.4.1\"; docs/paradox; unidoc"
         env:
           JAVA_OPTS: "-verbose:gc -Xmx4g"
 
       # Create directory structure upfront since rsync does not create intermediate directories otherwise
       - name: Create directory structure
         run: |-
-          mkdir -p target/nightly-docs/docs/pekko-http/1.4.0/
+          mkdir -p target/nightly-docs/docs/pekko-http/1.4.1/
           mkdir -p target/nightly-docs/docs/pekko-http/1.4/
-          cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko-http/1.4.0/docs
+          cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko-http/1.4.1/docs
           cp -r docs/target/paradox/site/main/ target/nightly-docs/docs/pekko-http/1.4/docs
           rm -r docs/target/paradox/site/main/
-          cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko-http/1.4.0/api
+          cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko-http/1.4.1/api
           cp -r target/scala-2.13/unidoc target/nightly-docs/docs/pekko-http/1.4/api
           rm -r target/scala-2.13/unidoc
-          cp -r target/javaunidoc target/nightly-docs/docs/pekko-http/1.4.0/japi
+          cp -r target/javaunidoc target/nightly-docs/docs/pekko-http/1.4.1/japi
           cp -r target/javaunidoc target/nightly-docs/docs/pekko-http/1.4/japi
           rm -r target/javaunidoc
 
@@ -71,7 +71,7 @@ jobs:
         with:
           upload: true
           switches: --archive --compress --update --delete --progress --relative
-          local_path: target/nightly-docs/./docs/pekko-http/1.4.0 # The intermediate dot is to show `--relative` which paths to operate on
+          local_path: target/nightly-docs/./docs/pekko-http/1.4.1 # The intermediate dot is to show `--relative` which paths to operate on
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/pekko/
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
           remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}

--- a/docs/src/main/paradox/release-notes/releases-1.4.md
+++ b/docs/src/main/paradox/release-notes/releases-1.4.md
@@ -1,5 +1,27 @@
 # 0. Release Notes (1.4.x)
 
+## 1.4.1
+
+Release notes for Apache Pekko HTTP 1.4.1. See [GitHub Milestone for 1.4.1](https://github.com/apache/pekko-http/milestone/16?closed=1) for a fuller list of changes.
+
+This is a bug fix release. It includes a number of hardening changes to the HTTP parsing and rendering code.
+
+### Bug Fixes
+* SSE: allow Unicode line terminators ([PR1186](https://github.com/apache/pekko-http/pull/1186))
+* Use `Locale.ROOT` for `toLowerCase`/`toUpperCase` and in the `RouteTest` header lookup ([PR1224](https://github.com/apache/pekko-http/pull/1224))
+* Parse `Content-Length` as digits with surrounding whitespace only ([PR1243](https://github.com/apache/pekko-http/pull/1243))
+* Render `Content-Length` for HEAD responses with a declared length ([PR1244](https://github.com/apache/pekko-http/pull/1244))
+* HTTP/2: bound incoming header blocks with `max-header-list-size` ([PR1247](https://github.com/apache/pekko-http/pull/1247))
+* Count repeated `Connection` headers towards `max-header-count` ([PR1268](https://github.com/apache/pekko-http/pull/1268))
+* Compare path elements when checking that a served file is below the base directory ([PR1269](https://github.com/apache/pekko-http/pull/1269))
+* Prevent CRLF injection through chunk trailers and extensions ([PR1270](https://github.com/apache/pekko-http/pull/1270))
+* HTTP/2: drop header fields containing CR, LF or NUL ([PR1271](https://github.com/apache/pekko-http/pull/1271))
+* Drop rendered headers containing NUL as well as CR and LF ([PR1272](https://github.com/apache/pekko-http/pull/1272))
+
+### Dependency Changes
+
+There are no dependency changes in this release.
+
 ## 1.4.0
 
 Release notes for Apache Pekko HTTP 1.4.0. See [GitHub Milestone for 1.4.0](https://github.com/apache/pekko-http/milestone/13?closed=1) for a fuller list of changes.


### PR DESCRIPTION
Adds the 1.4.1 release notes and points the 1.4 docs publishing workflow at 1.4.1.

Release is still under discussion.

### Release notes

`docs/src/main/paradox/release-notes/releases-1.4.md` gains a `1.4.1` section above `1.4.0`, listing the ten PRs in the [1.4.1 milestone](https://github.com/apache/pekko-http/milestone/16?closed=1) — the same set as `git log v1.4.0..1.4.x`, excluding the 1.4.0 release-notes commit and the two build/test-only changes that preceded them.

No third party dependency versions changed between v1.4.0 and the 1.4.x branch head, so the Dependency Changes section says so rather than listing upgrades.

### CI

`.github/workflows/publish-1.4-docs.yml` used `1.4.0` for the paradox/unidoc build version, the local staging directories and the rsync path. All occurrences are now `1.4.1`; the unversioned `1.4` paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)