### PR TITLE
feat: honour Raw-Request-URI as the HTTP/2 :path

### DIFF
--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -103,6 +103,16 @@ Scala
 Java
 :   @@snip [ModelDocTest.java](/docs/src/test/java/docs/http/javadsl/ModelDocTest.java) { #synthetic-header-s3 }
 
+The `Raw-Request-URI` header is honoured by both the HTTP/1.1 and the HTTP/2 client; over HTTP/2 its value is sent as
+the `:path` pseudo-header. It is consumed by the request engine and never rendered as a header of its own, and its
+value is used exactly as given — it is the caller's responsibility to supply a valid request target.
+
+This is the supported way to send a request target that @apidoc[Uri] cannot reproduce on its own. `Uri` percent-decodes
+path segments when parsing and re-encodes them with a keep-set that leaves sub-delims raw, so an encoded *pchar* does
+not survive the round trip — `%2B` is rendered back as `+`, for instance. Callers that must reproduce the target
+byte-for-byte should pass it through this header. AWS SigV4 is a typical case: the signature covers the encoded path,
+so an S3 object key containing `+` or `=` must reach the wire exactly as it was signed.
+
 ## HttpResponse
 
 An @apidoc[HttpResponse] consists of

--- a/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/http-core/src/main/scala/org/apache/pekko/http/impl/engine/http2/HttpMessageRendering.scala
@@ -20,6 +20,7 @@ import pekko.event.LoggingAdapter
 import pekko.http.impl.engine.http2.FrameEvent.ParsedHeadersFrame
 import pekko.http.impl.engine.rendering.DateHeaderRendering
 import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.`Raw-Request-URI`
 import pekko.http.scaladsl.settings.ClientConnectionSettings
 import pekko.http.scaladsl.settings.ServerSettings
 import pekko.util.OptionVal
@@ -73,9 +74,20 @@ private[http2] class RequestRendering(
     headerPairs += ":method" -> request.method.value
     headerPairs += ":scheme" -> request.uri.scheme
     headerPairs += ":authority" -> request.uri.authority.toString
-    headerPairs += ":path" -> request.uri.toHttpRequestTargetOriginForm.toString
+    // a `Raw-Request-URI` header supplies the request target verbatim, as it does in the HTTP/1.1 renderer. `Uri`
+    // percent-decodes path segments when parsing and re-encodes them with a keep-set that leaves sub-delims raw, so
+    // it cannot round-trip an encoded pchar (`%2B` renders as `+`). Callers that must reproduce the target
+    // byte-for-byte -- AWS SigV4 signs the encoded path, for instance -- pass it through this header.
+    headerPairs += ":path" -> rawRequestTarget(request).getOrElse(
+      request.uri.toHttpRequestTargetOriginForm.toString)
     headerPairs
   }
+
+  // `Raw-Request-URI` is a SyntheticHeader, so it is already excluded from the rendered header block by the
+  // `renderInRequests` filter and is only consumed here. As in HTTP/1.1, the value is taken as given: it is the
+  // caller's responsibility that it is a valid origin-form target.
+  private def rawRequestTarget(request: HttpRequest): Option[String] =
+    request.headers.collectFirst { case `Raw-Request-URI`(rawUri) => rawUri }
 
   override lazy val peerIdHeader: Option[(String, String)] =
     settings.userAgentHeader.map(h => h.lowercaseName -> h.value)

--- a/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/http2-tests/src/test/scala/org/apache/pekko/http/impl/engine/http2/Http2ClientSpec.scala
@@ -44,6 +44,7 @@ import pekko.http.scaladsl.model.headers.{
   `Cache-Control`,
   `Content-Length`,
   `Content-Type`,
+  `Raw-Request-URI`,
   RawHeader
 }
 import pekko.http.scaladsl.model.headers.CacheDirectives._
@@ -127,6 +128,41 @@ class Http2ClientSpec extends PekkoSpecWithMaterializer("""
               HPackSpecExamples.C61FirstResponseWithHuffman, None)),
           expectedResponse = HPackSpecExamples.FirstResponse)
       })
+
+      "send the Raw-Request-URI header verbatim as :path".inAssertAllStagesStopped(
+        new SimpleRequestResponseRoundtripSetup {
+          requestResponseRoundtrip(
+            streamId = 1,
+            // the `uri` is deliberately the lossy round-trip of the raw target, to show the header wins
+            request = HttpRequest(
+              uri = "https://www.example.com/a+b%20c",
+              headers = List(`Raw-Request-URI`("/a%2Bb%20c"))),
+            expectedHeaders = defaultExpectedHeaders.map {
+              case (":path", _) => ":path" -> "/a%2Bb%20c"
+              case other        => other
+            },
+            response = Seq(
+              HeadersFrame(streamId = 1, endStream = true, endHeaders = true,
+                HPackSpecExamples.C61FirstResponseWithHuffman, None)),
+            expectedResponse = HPackSpecExamples.FirstResponse)
+        })
+
+      "re-encode the path from the Uri when no Raw-Request-URI header is present".inAssertAllStagesStopped(
+        new SimpleRequestResponseRoundtripSetup {
+          requestResponseRoundtrip(
+            streamId = 1,
+            request = HttpRequest(uri = "https://www.example.com/a%2Bb%20c"),
+            // `Uri` decodes `%2B` when parsing and renders `+` back, since `+` is kept raw by the pchar keep-set.
+            // This is the round-trip loss that makes the `Raw-Request-URI` escape hatch necessary.
+            expectedHeaders = defaultExpectedHeaders.map {
+              case (":path", _) => ":path" -> "/a+b%20c"
+              case other        => other
+            },
+            response = Seq(
+              HeadersFrame(streamId = 1, endStream = true, endHeaders = true,
+                HPackSpecExamples.C61FirstResponseWithHuffman, None)),
+            expectedResponse = HPackSpecExamples.FirstResponse)
+        })
 
       "GOAWAY when the response has an invalid headers frame".inAssertAllStagesStopped(new TestSetup with NetProbes {
         val streamId = 0x1


### PR DESCRIPTION
### Motivation

Refs #1273.

That issue asks for a way to send a request whose path renders exactly as provided, because `Uri` cannot round-trip a percent-encoded path — it decodes segments when parsing and re-encodes them with the `pchar-base` keep-set, which leaves sub-delims raw, so `%2B` renders back as `+`. AWS SigV4 signs the encoded path, so an S3 object key containing `+` or `=` is rejected with `SignatureDoesNotMatch` after the round trip.

While investigating I found the issue's premise is only half right. The escape hatch it proposes (option 2, "a pre-rendered request target that the client renderer honors") **already exists for HTTP/1.1**: `HttpRequestRendererFactory` special-cases a `Raw-Request-URI` header and emits it verbatim as the request target. It is a `SyntheticHeader`, so it is not also rendered as a header line; it is covered by tests in `RequestRendererSpec` and documented under "synthetic headers" in `http-model.md`, whose example is literally an S3 path.

What is genuinely missing is HTTP/2. `RequestRendering.initialHeaderPairs` built `:path` from `request.uri.toHttpRequestTargetOriginForm` unconditionally and ignored the header, so the same `HttpRequest` produced a different request target depending on which protocol was negotiated.

### Modification

Take `Raw-Request-URI` into account when building `:path`, mirroring HTTP/1.1.

The header needs no new suppression logic: being a `SyntheticHeader` it was already excluded from the rendered header block by the existing `renderInRequests` filter, so it was silently dropped rather than mis-sent. As in HTTP/1.1, the value is used exactly as given — supplying a valid origin-form target is the caller's responsibility, and this is stated in the docs.

Also documents, in the existing synthetic-headers section of `http-model.md`, that the header is honoured by both clients, why it is needed (the `Uri` round-trip loss), and the SigV4 case.

### Result

`aws-spi-pekko-http`, and any proxy or pass-through use case that must not alter the request target, can pass `SdkHttpRequest.encodedPath()` through unchanged over HTTP/2 as well as HTTP/1.1.

This does not change the `Uri` model, so the round-trip limitation described in #1273 remains as such; it makes the existing escape hatch work uniformly across protocols. I'd suggest #1273 stays open if a raw `Uri.Path` representation is still wanted — that is a much larger change, since `Path` is a sealed ADT matched exhaustively across the codebase and in user code.

### Tests

Two cases added to `Http2ClientSpec`:

- a request carrying `Raw-Request-URI("/a%2Bb%20c")` sends that value as `:path`. The assertion compares the whole pseudo/header set, so it also pins that the header itself is not rendered. Verified this fails on `main` — `:path` comes out as `/a+b%20c` — and passes with the change.
- without the header, the path is still re-encoded from the `Uri`. This one passes both before and after; it is a characterization test that pins the round-trip loss (`/a%2Bb%20c` in, `/a+b%20c` out) which motivates the escape hatch.

`sbt "http2-tests/testOnly *Http2ClientSpec *Http2ClientServerSpec *Http2PersistentClientSpec *Http2ServerSpec"` — 183 pass. `sbt http-core/mimaReportBinaryIssues` — clean (the change is confined to an `@InternalApi private[http2]` class). Native `scalafmt` clean.

### References

Refs #1273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
