### PR TITLE
fix: filter the ParserSettingsImpl accessors shifted by max-part-count

### DIFF
--- a/http-core/src/main/mima-filters/2.0.x.backwards.excludes/max-part-count.excludes
+++ b/http-core/src/main/mima-filters/2.0.x.backwards.excludes/max-part-count.excludes
@@ -19,3 +19,11 @@
 ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.impl.engine.parsing.BodyPartParser#Settings.maxPartCount")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.javadsl.settings.ParserSettings.getMaxPartCount")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.http.scaladsl.settings.ParserSettings.maxPartCount")
+
+# maxPartCount was added as the 12th ParserSettingsImpl field, so every positional
+# case class accessor after it shifted by one. The shifted positions were already
+# filtered except for 22 and 25, whose result types now differ from 1.0.0.
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.http.impl.settings.ParserSettingsImpl._22")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.http.impl.settings.ParserSettingsImpl._25")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.http.impl.settings.ParserSettingsImpl.copy$default$22")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.http.impl.settings.ParserSettingsImpl.copy$default$25")


### PR DESCRIPTION
## Motivation

`maxPartCount` was added as the 12th field of `ParserSettingsImpl` in #1266, which shifted every positional case class accessor after it by one. MiMa checks `pekko-http-core` against 1.0.0, and the existing filters covered the positions that had already moved (12-21, 24, 26) but not 22 and 25, whose result types now differ from 1.0.0.

As a result `validatePullRequest` fails on `main` for every open PR:

- Scala 2.13 reports `copy$default$22` and `copy$default$25`
- Scala 3 additionally reports the `_22` and `_25` accessors

```
* synthetic method copy$default$22()Boolean in class org.apache.pekko.http.impl.settings.ParserSettingsImpl
  has a different result type in current version, where it is scala.collection.immutable.Map rather than Boolean
* synthetic method copy$default$25()scala.Function1 in class org.apache.pekko.http.impl.settings.ParserSettingsImpl
  has a different result type in current version, where it is Boolean rather than scala.Function1
```

## Modification

Add the four missing `IncompatibleResultTypeProblem` filters to `max-part-count.excludes`, the file introduced by the change that caused the shift, with a comment recording why those two positions moved.

## Result

`http-core/mimaReportBinaryIssues` passes again on Scala 2.13 and Scala 3, unblocking MiMa validation for open PRs. `ParserSettingsImpl` is `@InternalApi private[pekko]`, so the shifted synthetic accessors are not part of the public API.

## Tests

- `sbt "http-core/mimaReportBinaryIssues"` - success (Scala 2.13.18)
- `sbt "++3.3.8" "http-core/mimaReportBinaryIssues"` - success (Scala 3.3.8)

No test sources changed - this is a MiMa filter-only change.

## References

- Failing job: https://github.com/apache/pekko-http/actions/runs/34544677238/job/103094612413
- Shift introduced by #1266
